### PR TITLE
bump up font-sizes

### DIFF
--- a/lib/sass/calcite-web/components/_button.scss
+++ b/lib/sass/calcite-web/components/_button.scss
@@ -14,12 +14,11 @@
   background-color: $blue;
   @include box-sizing(border-box);
   @include transition(all 0.05s linear);
+  @include font-size(0);
   cursor: pointer;
   white-space: nowrap;
   @if $include-type {
-    @include font-size(-1);
     font-family: $header-family;
-    font-weight: 400;
   }
   &:hover, &:focus {
     background-color: $dark-blue;
@@ -99,7 +98,7 @@
   }
 
   @mixin btn-large() {
-    @include font-size(0);
+    @include font-size(1);
     padding: .5rem 1rem .5rem;
   }
 

--- a/lib/sass/calcite-web/patterns/_side-nav.scss
+++ b/lib/sass/calcite-web/patterns/_side-nav.scss
@@ -14,9 +14,8 @@
 
   @mixin side-nav-title() {
     margin: 0;
-    padding: $baseline/3;
+    padding: $baseline/2;
     @extend .header-face;
-    @include font-size(-1);
     background-color: $off-white;
     border-top: 1px solid $lightest-gray;
     &:first-child {
@@ -27,8 +26,8 @@
   @mixin side-nav-link() {
     display: block;
     @include box-sizing(border-box);
-    padding: $baseline/3;
-    @include font-size(-2);
+    padding: $baseline/2;
+    @include font-size(-1);
     @extend .link-darker-gray;
     background-color: $white;
     border-top: 1px solid $lightest-gray;

--- a/lib/sass/calcite-web/patterns/_sub-nav.scss
+++ b/lib/sass/calcite-web/patterns/_sub-nav.scss
@@ -14,7 +14,7 @@
     display: inline-block;
     float: left;
     line-height: 1.25;
-    @extend .header-light;
+    @extend .header-face;
   }
 
   @mixin sub-nav-list() {
@@ -24,12 +24,11 @@
   }
 
   @mixin sub-nav-link() {
-    padding: .25em .75em;
+    padding: .375em 1em;
     margin: 0 .25em 0 0;
     float: left;
     font-family: $header-family;
     color: $lightest-gray;
-    @include font-size(-1);
     background-color: $transparent-off-black;
     @include transition(background-color $transition, color 150ms $transition);
     &:hover, &:focus {

--- a/lib/sass/calcite-web/patterns/_third-nav.scss
+++ b/lib/sass/calcite-web/patterns/_third-nav.scss
@@ -7,7 +7,7 @@
   @extend .header-face;
   border-bottom: 1px solid $lighter-gray;
   background-color: $white;
-  padding: $baseline/4 0;
+  padding: $baseline/2 0;
   width: 100%;
   nav {
     margin-left: $baseline * .5;
@@ -16,7 +16,7 @@
 
   @mixin third-nav-link() {
     @extend .link-darkest-gray;
-    @include font-size(-2);
+    @include font-size(-1);
     margin-right: $baseline * 0.75;
     &.is-active {
       @extend .header-bold;

--- a/lib/sass/calcite-web/patterns/_top-nav.scss
+++ b/lib/sass/calcite-web/patterns/_top-nav.scss
@@ -9,7 +9,7 @@
 }
 
   @mixin top-nav-title {
-    @include font-size(1);
+    @include font-size(2);
     @extend .link-off-black;
     float: left;
     padding-right: 2rem;

--- a/lib/sass/calcite-web/type/_faces.scss
+++ b/lib/sass/calcite-web/type/_faces.scss
@@ -60,13 +60,13 @@
 
 @mixin body-face() {
   @include tracking($body-tracking);
-  font-family: $body-family; font-weight: 300; font-style: normal;
+  font-family: $body-family; font-weight: 500; font-style: normal;
   b, strong {font-weight: 700;}
 }
 
 @mixin body-italic() {
   @include tracking($body-tracking);
-  font-family: $body-family; font-weight: 300; font-style: italic;
+  font-family: $body-family; font-weight: 500; font-style: italic;
   b, strong {font-weight: 700;}
 }
 

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -9,7 +9,6 @@
   @if $include-body-family == true {
     body {
       @extend .body-face;
-      @include font-size(-1);
       line-height: $baseline;
       color: $type-color;
 


### PR DESCRIPTION
@nikolaswise @paulcpederson  Since I couldn't commit to any of my own projects I decided to mess around with yours!

On initial load I found everything really difficult to read. Font weights generally seemed to light and font sizes to small. Here is a before/after screenshots of this from my Thunderbolt display.

![calcite_web___esri_design_patterns](https://cloud.githubusercontent.com/assets/378557/5532807/c3a05756-89f1-11e4-94d3-c2c813991583.png)

![calcite_web___esri_design_patterns](https://cloud.githubusercontent.com/assets/378557/5532811/d70092de-89f1-11e4-805c-5200bb9256e4.png)

We need to default to larger and thicker fonts. Its probably worth testing this on some crappy screens but also we need to think about readability. I almost immediately bumped up the browser font size when visiting the docs site. Something I really shouldn't feel a need to do.
