### PR TITLE
Ignore OSX cruft for archives

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -192,7 +192,7 @@ module.exports = function(grunt) {
         },
         files: [
           {
-            src: ['dist/**'],
+            src: ['dist/**', '!dist/__MACOSX'],
             dest: './'
           },
         ]


### PR DESCRIPTION
Currently, the `__MACOSX` directory gets dumped into the downloadable release, ignore this directory.
