### PR TITLE
Fix string interpolation for keyframe names

### DIFF
--- a/lib/sass/calcite-web/utils/_keyframes.scss
+++ b/lib/sass/calcite-web/utils/_keyframes.scss
@@ -5,10 +5,10 @@
 //  ↳ components → _utility-mixins.md
 
 @mixin keyframes ($name) {
-  @-webkit-keyframes $name {
+  @-webkit-keyframes #{$name} {
     @content;
   }
-  @keyframes $name {
+  @keyframes #{$name} {
     @content;
   }
 }


### PR DESCRIPTION
This keeps breaking for me.
