### PR TITLE
fix modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Modals not blurry
+
 ## 0.5.2
 
 ### Added

--- a/docs/source/patterns/sample-code/_modals.html
+++ b/docs/source/patterns/sample-code/_modals.html
@@ -1,6 +1,6 @@
 <div class="js-modal modal-overlay {{modifier}}" data-modal="foo">
   <div class="modal-content column-12">
-    <a class="js-modal-toggle icon-close right" href="#">x</a>
+    <a class="js-modal-toggle icon-ui-close font-size-1 right" href="#" aria-label="close modal"></a>
     <h3>Modal!</h3>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,

--- a/lib/sass/calcite-web/patterns/_modal.scss
+++ b/lib/sass/calcite-web/patterns/_modal.scss
@@ -4,43 +4,60 @@
 //  ↳ http://esri.github.io/calcite-web/patterns/#modals
 //  ↳ patterns → _modals.md
 
+$easing-function: cubic-bezier(0.215, 0.440, 0.420, 0.880);
+
 @mixin modal-overlay() {
-  display: none;
-  background: $transparent-black;
-  overflow-y: scroll;
   position: fixed;
   top: 0;
+  right: 0;
   bottom: 0;
   left: 0;
-  right: 0;
+  overflow-y: scroll;
+  text-align: center;
+  opacity: 0;
+  visibility: hidden;
+  background: $transparent-black;
+  @include transition(visibility 0ms linear 300ms, opacity 300ms $easing-function);
   z-index: 50;
   &.is-active {
-    display: block;
+    visibility: visible;
+    opacity: 1;
+    @include transition-delay(0ms);
+    .modal-content {
+      visibility: visible;
+      opacity: 1;
+      @include transition-delay(0ms);
+      @include transform(translate3d(0,0,0))
+    }
+  }
+  &:before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin-right: -0.25em; /* Adjusts for spacing */
   }
 }
 
   @mixin modal-content() {
-    @include box-sizing(border-box);
-    position: relative;
-    top: 45vh;
-    left: 50vw;
-    @include transform(translate3d(-50%, -50%, 0));
+    box-sizing: border-box;
     max-height: 80vh;
     z-index: 100;
-    background: $off-white;
-    border: 1px solid $lightest-gray;
+    float: none;
+    background: $white;
     padding: $baseline;
-    opacity: 1;
+    text-align: left;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+    display: inline-block;
+    vertical-align: middle;
+    opacity: 0;
+    visibility: hidden;
+    @include transition-prefixed(transform 300ms $easing-function, visibility 0ms linear 300ms, opacity 300ms $easing-function);
+    @include transform(translate3d(0, 20px, 0))
   }
 
 @if $include-modal == true {
   .modal-overlay { @include modal-overlay() ;}
   .modal-content { @include modal-content() ;}
-  .ie9 {
-    .modal-content {
-      -ms-transform:translate(-50%,-50%);
-    }
-  }
 }


### PR DESCRIPTION
fix modals being blurry by using a pseudo element that was vertical-align middle:

![ghost](https://cloud.githubusercontent.com/assets/1031758/7975443/aeeb8bc6-0a22-11e5-8d8b-cf613665fda3.png)

Also added some transitions and a proper `icon-ui-close` so that modals are now quite delightful!
