### PR TITLE
Allow use of .panel > .grid-container > .column

### DIFF
--- a/lib/sass/calcite-web/components/_panel.scss
+++ b/lib/sass/calcite-web/components/_panel.scss
@@ -12,7 +12,7 @@
   & > :last-child {
     margin-bottom: 0;
   }
-  [class*="column-"] {
+  > [class*="column-"] {
     @include gutter-left(1.5);
     @include gutter-right(1.5);
   }


### PR DESCRIPTION
This restores the use case of using panel to create background colors while still fixing nesting columns inside panels.
