### PR TITLE
Remove special treatment for pre > code in tabs

### DIFF
--- a/lib/sass/calcite-web/patterns/_tabs.scss
+++ b/lib/sass/calcite-web/patterns/_tabs.scss
@@ -46,6 +46,10 @@
   @include box-sizing(border-box);
   border: 1px solid $lighter-gray;
   margin-top: -1px;
+  pre code {
+    border: none;
+    background-color: transparent;
+  }
 }
 
 @mixin tab-section() {
@@ -86,6 +90,10 @@
     border-bottom: none;
     border-left: none;
     border-right: none;
+    pre code {
+      border: 1px solid $lightest-gray;
+      background-color: $off-white;
+    }
   }
   .tab-section  {
     background-color: transparent;


### PR DESCRIPTION
I can't seem to find any good reason removing this breaks anything, but it is messing up my styles as i build the documentation pages.
