### PR TITLE
Various top nav fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Unreleased
+
+### Fixed
+
+- Alignment of items in top nav with top of page
+
+### Changed
+
+- Made user image in top nav smaller and with less padding
+- `.top-nav-dropdown` should now be added to the `.dropdown` element
+
+### Added
+
+- `.top-nav-icon-link` for creating links that are just icons in the top nav
+
 ## 0.14.0
 
 ### Fixed

--- a/lib/sass/calcite-web/components/_dropdown.scss
+++ b/lib/sass/calcite-web/components/_dropdown.scss
@@ -13,7 +13,7 @@
 }
 
   @mixin dropdown-btn {
-    padding-right: 2rem;
+    padding-right: 1rem;
     cursor: pointer;
     position: relative;
     &:after {
@@ -21,7 +21,7 @@
       @extend %icon-font-after;
       @extend .icon-ui-down-arrow:before;
       position: absolute;
-      right: .75rem;
+      right: .25rem;
     }
   }
 
@@ -48,4 +48,3 @@
     white-space: nowrap;
   }
 }
-

--- a/lib/sass/calcite-web/patterns/_top-nav.scss
+++ b/lib/sass/calcite-web/patterns/_top-nav.scss
@@ -59,7 +59,7 @@ $topnav-link-overline: linear-gradient(to top, transparent 92%, $blue 93%, $blue
     }
   }
 
-  @mixin top-nav-link {
+  @mixin top-nav-style {
     @include font-size(-1);
     @extend .avenir-regular;
     color: $off-black;
@@ -67,15 +67,17 @@ $topnav-link-overline: linear-gradient(to top, transparent 92%, $blue 93%, $blue
     padding-bottom: .75*$baseline;
     line-height: 1.5rem;
     display: inline-block;
+    vertical-align: top;
+  }
+
+  @mixin top-nav-link {
+    @include top-nav-style();
     &:hover, &:focus {
       color: $blue;
       background: url('#{$image-path}/top-nav-ie9.gif') repeat-x top left transparent;
       @include prefixer(background-image, $topnav-link-overline, webkit moz o);
       background-image: $topnav-link-overline;
       text-decoration: none;
-      a {
-        color: $blue;
-      }
     }
     &:focus {
       outline: none;
@@ -84,7 +86,18 @@ $topnav-link-overline: linear-gradient(to top, transparent 92%, $blue 93%, $blue
       @include prefixer(background-image, $topnav-link-overline, webkit moz o);
       background-image: $topnav-link-overline;
     }
-    &.dropdown-btn {
+  }
+
+  @mixin top-nav-logo {
+    margin-top: 0.75*$baseline;
+  }
+
+  @mixin top-nav-dropdown {
+    @include top-nav-style();
+    .dropdown-btn {
+      @include font-size(-1);
+      @extend .avenir-regular;
+      color: $off-black;
       padding-right: 1rem;
       @if ($include-right-to-left) {
         html[dir="rtl"] & {
@@ -92,8 +105,18 @@ $topnav-link-overline: linear-gradient(to top, transparent 92%, $blue 93%, $blue
           padding-left: 1rem;
         }
       }
+      &:hover, &:focus {
+        color: $blue;
+        text-decoration: none;
+      }
+      &:focus {
+        outline: none;
+      }
       &:after {
         right: 0;
+        content: "▼";
+        font-size: .5rem;
+        vertical-align: .125rem;
         @if ($include-right-to-left) {
           html[dir="rtl"] & {
             right: auto;
@@ -102,30 +125,23 @@ $topnav-link-overline: linear-gradient(to top, transparent 92%, $blue 93%, $blue
         }
       }
     }
-    a {
-      color: $off-black;
-      &:hover {
-        text-decoration: none;
-      }
+  }
+
+  @mixin top-nav-icon-link {
+    @include top-nav-style();
+    @include font-size(1);
+    &:before {
+      top: 2.5rem;
     }
-  }
-
-  @mixin top-nav-logo {
-    margin-top: 0.75*$baseline;
-  }
-
-  @mixin top-nav-dropdown {
     &:after {
-      padding-left: $baseline / 4;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          padding-left: 0;
-          padding-right: $baseline / 4;
-        }
+      top:2.825rem;
+    }
+    span {
+      position: relative;
+      top: 3px;
+      &:before {
+        padding: 0;
       }
-      content: "▼";
-      font-size: .5rem;
-      vertical-align: .125rem;
     }
   }
 
@@ -147,6 +163,7 @@ $topnav-link-overline: linear-gradient(to top, transparent 92%, $blue 93%, $blue
     .top-nav-list {@include top-nav-list();}
     .top-nav-link {@include top-nav-link();}
     .top-nav-dropdown {@include top-nav-dropdown();}
+    .top-nav-icon-link {@include top-nav-icon-link();}
   .sign-in {@include sign-in();}
 
   // TEMP. REMOVE FOR 1.0

--- a/lib/sass/calcite-web/patterns/_user-nav.scss
+++ b/lib/sass/calcite-web/patterns/_user-nav.scss
@@ -6,13 +6,13 @@
 
 @mixin user-name () {
   padding: $baseline/4;
+  color: $off-black;
 }
 
 @mixin user-image () {
-  width: $baseline;
-  height: $baseline;
-  margin-right: $baseline / 4;
-  vertical-align: -$baseline / 4;
+  width: 1.2rem;
+  height: 1.2rem;
+  vertical-align: -0.25rem;
 }
 
 @if $include-user-nav == true {


### PR DESCRIPTION
As a part of https://github.com/ArcGIS/arcgis-for-developers/pull/3003 I made a few tweaks and changes to the top nav pattern.
- Everything gets `vertical-align:top;` - this makes the border at the top line up properly
- `.top-nav-dropdown` is now a class that should sit at the same level as `.top-nav-list` this makes styling it way easier and it makes layout easier
- Added a `top-nav-icon-link` class for making icon rows in the top nav like on developers
- tweaks to the `user-nav-*` classes to make things line up better
