### PR TITLE
Fix stickys

### DIFF
--- a/lib/js/calcite-web.js
+++ b/lib/js/calcite-web.js
@@ -119,31 +119,32 @@
   // return a funciton that will only execute
   // once it is NOT called for delay milliseconds
   function throttle(fn, time, context) {
-		var lock, args, wrapperFn, later;
+    var lock, args, wrapperFn, later;
 
-		later = function () {
-			// reset lock and call if queued
-			lock = false;
-			if (args) {
-				wrapperFn.apply(context, args);
-				args = false;
-			}
-		};
+    later = function () {
+      // reset lock and call if queued
+      lock = false;
+      if (args) {
+        wrapperFn.apply(context, args);
+        args = false;
+      }
+    };
 
-		wrapperFn = function () {
-			if (lock) {
-				// called too soon, queue to call later
-				args = arguments;
+    wrapperFn = function () {
+    if (lock) {
+      // called too soon, queue to call later
+      args = arguments;
 
-			} else {
-				// call and lock until later
-				fn.apply(context, arguments);
-				setTimeout(later, time);
-				lock = true;
-			}
-		};
+      } else {
+      // call and lock until later
+      fn.apply(context, arguments);
 
-		return wrapperFn;
+      setTimeout(later, time);
+        lock = true;
+      }
+    };
+
+    return wrapperFn;
 	}
   // ┌────────────────────┐
   // │ Class Manipulation │


### PR DESCRIPTION
sticky elements now check against their height on every firing of scroll or resize. This has been wrapped in a throttle function to not check more then every 100 ms.
