### PR TITLE
remove underline on icons in links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Removed underlines on `:hover` for icons inside of links
+
 ## 0.15.1
 
 ### Fixed

--- a/bin/webfont-template.scss
+++ b/bin/webfont-template.scss
@@ -20,6 +20,8 @@
   text-transform: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  display: inline-block;
+  text-decoration: none;
 }
 
 %icon-font-styles {


### PR DESCRIPTION
having the underline apply to the icon when you hover a link was getting pretty annoying to me. @nikolaswise do you think `display: inline-block;` will have any disasterous side effects?
