### PR TITLE
small update to select[multiple]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Modified
+- small visual update to multiple select elements
+
 ## 1.0.0-beta.11
 
 ### Fixed

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -207,7 +207,11 @@
   select[multiple] {
     height: auto;
     background-image: none;
-    padding: $baseline/5 $baseline/4 $baseline/5 $baseline/4;
+    padding: 0;
+  }
+
+  select[multiple] option {
+    padding: $baseline/5;
   }
 
   /* Select Browser Hacks */


### PR DESCRIPTION
I thought the `select[multiple]` element looked a bit off. Removed the padding from the select and added it to the option. It looks like this now:

<img width="452" alt="screen shot 2016-04-01 at 9 53 40 pm" src="https://cloud.githubusercontent.com/assets/1031758/14224525/93a969ac-f854-11e5-9192-8df9d03cdafc.png">

Which I think makes it look a little more like our existing patterns like side nav, dropdown, drawers, etc.

/cc @nikolaswise 