### PR TITLE
make red buttons outlined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Modified
 - More clear focus state for dropdown links
 - Make dropdown `:hover` and `is-active` state consistent with side nav
+- red buttons are now outlined instead of solid red
 
 ## 1.0.0-beta.19
 

--- a/lib/sass/calcite-web/components/_button.scss
+++ b/lib/sass/calcite-web/components/_button.scss
@@ -134,6 +134,17 @@
     }
   }
 
+  @mixin btn-red() {
+    color: $red;
+    background: transparent;
+    border-color: $red;
+    &:hover {
+      color: $white;
+      background: $dark-red;
+      border-color: $dark-red;
+    }
+  }
+
   @mixin btn-color($value, $hover-value) {
     background-color: $value;
     border-color: $value;
@@ -154,7 +165,7 @@
   .btn-half        { @include btn-half();}
   .btn-grouped     { @include btn-grouped();}
   .btn-white       { @include btn-white();}
-  .btn-red         { @include btn-color($red, $dark-red);}
+  .btn-red         { @include btn-red();}
   .btn-green       { @include btn-color($green, $dark-green);}
   .btn:disabled, .btn-disabled, button[disabled] { @include btn-disabled(); }
 }


### PR DESCRIPTION
solid red buttons call far too much attention to themselves. Since red is usually used as a destructive action, it's important for it to not be the top of the visual hierarchy.