### PR TITLE
translucent tab pattern - light and dark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Unreleased
 
+### Added
+- `translucent-tab` pattern added
+
 ### Fixed
 - checkboxes and radio buttons left alignment in IE10
 - `user-nav` pattern in IE10 (#591)
 - `dropdown-btn` in IE10
+- `backgound` changed to `background` in tab transition
 
 ## 1.0.0-beta.22
 

--- a/docs/source/table_of_contents.yml
+++ b/docs/source/table_of_contents.yml
@@ -509,6 +509,8 @@ patterns:
           modifiers:
             - 'tabs-gray'
             - 'tabs-transparent'
+            - 'tabs-translucent'
+            - 'tabs-translucent tabs-dark'
         - title: 'Accordions'
           link: accordions
           modifiers: true

--- a/lib/sass/calcite-web/patterns/_tabs.scss
+++ b/lib/sass/calcite-web/patterns/_tabs.scss
@@ -11,7 +11,7 @@
 @mixin tab-title() {
   @include box-sizing(border-box);
   @include font-size(-2);
-  @include transition(backround, $transition);
+  @include transition(background, $transition);
   padding: $baseline/4 $baseline/2;
   float: left;
   white-space: nowrap;
@@ -106,6 +106,59 @@
   }
 }
 
+@mixin tabs-translucent() {
+  .tab-title    {
+    background-color: rgba(255,255,255,0.7);
+    border: 1px solid transparent;
+    border-bottom: none;
+    color: $off-black;
+    margin-right: 2px;
+    margin-bottom: 1px;
+    &:hover {
+      background-color: rgba(255,255,255,0.8);
+      background-image: none;
+      @include prefixer(background-image,linear-gradient(to top, transparent 94%, $blue 96%, $blue 100%), webkit moz o);
+      background-image:linear-gradient(to top, transparent 94%, $blue 96%, $blue 100%);
+    }
+    &.is-active {
+      background-color: rgba(255,255,255,0.8);
+      background-image: none;
+      border-bottom: none;
+      padding-bottom: 0.5rem;
+      @include prefixer(background-image,linear-gradient(to top, transparent 94%, $blue 96%, $blue 100%), webkit moz o);
+      background-image:linear-gradient(to top, transparent 94%, $blue 96%, $blue 100%);
+    }
+  }
+  .tab-contents {
+    border: none;
+  }
+  .tab-section  {
+    background-color: rgba(255,255,255,0.8);
+  }
+}
+
+@mixin tabs-dark() {
+  .tab-title    {
+    background-color: rgba(0,0,0,0.7);
+    color: $white;
+    &:hover {
+      background-color: rgba(0,0,0,0.8);
+      @include prefixer(background-image,linear-gradient(to top, transparent 94%, $white 96%, $white 100%), webkit moz o);
+      background-image:linear-gradient(to top, transparent 94%, $white 96%, $white 100%);
+    }
+    &.is-active {
+      background-color: rgba(0,0,0,0.8);
+      @include prefixer(background-image,linear-gradient(to top, transparent 94%, $white 96%, $white 100%), webkit moz o);
+      background-image:linear-gradient(to top, transparent 94%, $white 96%, $white 100%);
+    }
+  }
+
+  .tab-section  {
+    background-color: rgba(0,0,0,0.8);
+    color: $white;
+  }
+}
+
 @if $include-tabs == true {
   .tab-nav         { @include tab-nav()          ;}
   .tab-title       { @include tab-title()        ;}
@@ -113,4 +166,6 @@
   .tab-section     { @include tab-section()      ;}
   .tabs-gray       { @include tabs-gray()        ;}
   .tabs-transparent{ @include tabs-transparent() ;}
+  .tabs-translucent{ @include tabs-translucent() ;}
+  .tabs-dark{ @include tabs-dark() ;}
 }


### PR DESCRIPTION
- added modifier to table of contents
- adding translucent pattern `.tabs-translucent` for tabs
- dark variation of translucent with modifier `.tabs-dark`
- fixed issue with default transition being spelled wrong `backround` to `background`