### PR TITLE
add grunt stat method to get basic stats about css bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -318,6 +318,12 @@ module.exports = function (grunt) {
       },
       lint: {
         command: 'node_modules/.bin/semistandard | snazzy'
+      },
+      stat: {
+        command: 'npm run cssStat'
+      },
+      statLog: {
+        command: 'node ./bin/stat.js'
       }
     },
 
@@ -344,5 +350,6 @@ module.exports = function (grunt) {
   grunt.registerTask('deploy', ['doc', 'gh-pages']);
   grunt.registerTask('s3', ['dist', 'prompt:aws', 'aws_s3']);
   grunt.registerTask('release', ['shell:release', 'prompt:aws', 'aws_s3']);
+  grunt.registerTask('stat', ['sass', 'copy', 'shell:stat', 'shell:statLog']);
   grunt.registerTask('default', ['doc', 'http-server', 'watch']);
 };

--- a/bin/stat.js
+++ b/bin/stat.js
@@ -1,6 +1,6 @@
-var stats = require('../dist/css/stats.json')
+var stats = require('../dist/css/stats.json');
 
-console.log('size:      ' + stats.humanizedSize)
-console.log('gzipped:   ' + stats.humanizedGzipSize)
-console.log('rules:     ' + stats.rules.total)
-console.log('selectors: ' + stats.selectors.total)
+console.log('size:      ' + stats.humanizedSize);
+console.log('gzipped:   ' + stats.humanizedGzipSize);
+console.log('rules:     ' + stats.rules.total);
+console.log('selectors: ' + stats.selectors.total);

--- a/bin/stat.js
+++ b/bin/stat.js
@@ -1,0 +1,6 @@
+var stats = require('../dist/css/stats.json')
+
+console.log('size:      ' + stats.humanizedSize)
+console.log('gzipped:   ' + stats.humanizedGzipSize)
+console.log('rules:     ' + stats.rules.total)
+console.log('selectors: ' + stats.selectors.total)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/esri/calcite-web",
   "scripts": {
     "test": "semistandard | snazzy",
+    "cssStat": "cssstats dist/css/calcite-web.css dist/css/stats.json",
     "a11y": "a11y local.arcgis.com:8888",
     "gh-release": "gh-release -a calcite-web.zip",
     "acetate": "acetate build -i docs/source -o docs/build -c docs/acetate.conf.js",
@@ -45,6 +46,7 @@
     "acetate-cli": "0.0.3",
     "arraystream": "0.0.5",
     "babel-preset-es2015-rollup": "^1.1.1",
+    "cssstats-cli": "^1.0.0-beta.2",
     "gh-release": "^2.0.1",
     "glob": "^5.0.6",
     "grunt": "^0.4.5",


### PR DESCRIPTION
@nikolaswise this adds a grunt task that will build sass and then spit out some stats on the main bundle (`dist/css/calcite-web.css`).

Just run `grunt stat` and it will build everything and then output some info:

```
size:      354kB
gzipped:   33kB
rules:     3182
selectors: 4452
```

This is a really dumb version of something that could be really cool, but it will at least give us an easy way to trouble shoot the the IE9 limit problem.