### PR TITLE
implement block-groups with flex-box

### DIFF
--- a/lib/sass/calcite-web/grid/_block-groups.scss
+++ b/lib/sass/calcite-web/grid/_block-groups.scss
@@ -4,40 +4,71 @@
 //  ↳ http://esri.github.io/calcite-web/grid/#block-groups
 //  ↳ grid → _block-groups.md
 
+$half-gutter: 0.75 * $column-gutter;
+$full-gutter: $half-gutter * 2;
+
 @mixin block-group() {
-  font-family: monospace;
-  letter-spacing: -.65em;
-  margin-left: -0.5*$column-gutter;
-  margin-right: -0.5*$column-gutter;
-  text-align: left;
-  display: block;
-  &.center {
-    text-align: center;
-  }
+  margin-left: -$half-gutter;
+  margin-right: -$half-gutter;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 @mixin block() {
-  font-family: $avenir-family;
-  position: relative;
-  display: inline-block;
-  float: none;
   @include box-sizing(border-box);
-  padding-left: 0.5*$column-gutter;
-  padding-right: 0.5*$column-gutter;
-  letter-spacing: normal;
-  text-align: left;
-  vertical-align: top;
+  margin-left: $half-gutter;
+  margin-right: $half-gutter;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
 }
 
 @mixin _block-grid ($prefix: "") {
-  .#{$prefix}block-group-1-up .block { width: 100%; }
-  .#{$prefix}block-group-2-up .block { width: 50%; }
-  .#{$prefix}block-group-3-up .block { width: 33.33333%; }
-  .#{$prefix}block-group-4-up .block { width: 25%; }
-  .#{$prefix}block-group-5-up .block { width: 20%; }
-  .#{$prefix}block-group-6-up .block { width: 16.66666%; }
-  .#{$prefix}block-group-7-up .block { width: 14.28570%; }
-  .#{$prefix}block-group-8-up .block { width: 12.5%; }
+  .#{$prefix}block-group-1-up .block {
+    -ms-flex-preferred-size: calc(100% - #{$full-gutter});
+                 flex-basis: calc(100% - #{$full-gutter});
+                 width: calc(100% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-2-up .block {
+    -ms-flex-preferred-size: calc(50% - #{$full-gutter});
+                 flex-basis: calc(50% - #{$full-gutter});
+                 width: calc(50% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-3-up .block {
+    -ms-flex-preferred-size: calc(33.33333% - #{$full-gutter});
+                 flex-basis: calc(33.33333% - #{$full-gutter});
+                 width: calc(33.33333% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-4-up .block {
+    -ms-flex-preferred-size: calc(25% - #{$full-gutter});
+                 flex-basis: calc(25% - #{$full-gutter});
+                 width: calc(25% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-5-up .block {
+    -ms-flex-preferred-size: calc(20% - #{$full-gutter});
+                 flex-basis: calc(20% - #{$full-gutter});
+                 width: calc(20% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-6-up .block {
+    -ms-flex-preferred-size: calc(16.66666% - #{$full-gutter});
+                 flex-basis: calc(16.66666% - #{$full-gutter});
+                 width: calc(16.66666% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-7-up .block {
+    -ms-flex-preferred-size: calc(14.28570% - #{$full-gutter});
+                 flex-basis: calc(14.28570% - #{$full-gutter});
+                 width: calc(14.28570% - #{$full-gutter});
+  }
+  .#{$prefix}block-group-8-up .block {
+    -ms-flex-preferred-size: calc(12.5% - #{$full-gutter});
+                 flex-basis: calc(12.5% - #{$full-gutter});
+                 width: calc(12.5% - #{$full-gutter});
+  }
 }
 
 @if $block-grid == true {
@@ -58,5 +89,11 @@
 
   @include respond-to($small) {
     @include _block-grid($small-class + '-');
+  }
+  .ie9 .block {
+    float: left;
+  }
+  .ie9 .block-group {
+    @include clearfix();
   }
 }


### PR DESCRIPTION
There is no CHANGELOG because developers use it exactly the same. It should just swap out flawlessly with the old implementation.

Because flex-box is IE10+, I make the `block` class float in IE9 and add a `clearfix` to the `block-group` class. So visually it still works. 

Another nice thing about this implementation is that the gutters are done with margin instead of padding, meaning you don't have to wrap each block in an additional div.

I have tested this on the example page on IE9, IE10, IE11, Safari, Firefox, and Chrome. Seems to work great. It will also enable us to have equal height blocks by default which is pretty cool.

/cc @nikolaswise 