### PR TITLE
Updating how to install via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ That will give you everything including sass utilities. You will also need to co
 To install Calcite Web with npm, type:
 
 ```
-npm install --save-dev Esri/calcite-web#v1.0.0-beta.25
+npm install --save-dev "Esri/calcite-web#v1.0.0-beta.30"
 ```
 
 You must add the current version in order to get the `dist/` folder.


### PR DESCRIPTION
I had problems trying to install without the double quotes, i got an error -> zsh: no matches found: Esri/calcite-web#v1.0.0-beta.30