### PR TITLE
fix rounding error in pre+post column sizing

### DIFF
--- a/lib/sass/calcite-web/grid/_columns.scss
+++ b/lib/sass/calcite-web/grid/_columns.scss
@@ -95,7 +95,7 @@
           width: ($n / $large-column-count) * $container-width;
           max-width: ($n / $large-column-count) * $max-width;
           > .#{$prefix}column-#{$n} {
-            margin-left: -($column-gutter/2);
+            margin-left: -$column-gutter / 2;
             margin-right: -$column-gutter / 2;
           }
         }
@@ -107,11 +107,11 @@
         }
       }
       .#{$prefix}#{$large-class}-first-column {
-        margin-left: -($column-gutter / 2);
+        margin-left: -$column-gutter / 2;
         margin-right: -$column-gutter / 2;
       }
       .#{$prefix}#{$large-class}-last-column {
-        margin-right: -($column-gutter / 2);
+        margin-right: -$column-gutter / 2;
         margin-left: -$column-gutter / 2;
       }
     }

--- a/lib/sass/calcite-web/grid/_pre-post.scss
+++ b/lib/sass/calcite-web/grid/_pre-post.scss
@@ -106,15 +106,15 @@
     @media screen and (min-width: $magic-number + 3) {
       @for $n from 0 through $large-column-count {
         .pre-#{$n}  {
-          margin-left: ($n / $large-column-count) * $container-width !important;
+          margin-left: ($n / $large-column-count) * $container-width - 1 !important;
           html[dir="rtl"] & {
-            margin-right: ($n / $large-column-count) * $container-width !important;
+            margin-right: ($n / $large-column-count) * $container-width - 1 !important;
           }
         }
         .post-#{$n} {
-          margin-right: ($n / $large-column-count) * $container-width !important;
+          margin-right: ($n / $large-column-count) * $container-width - 1 !important;
           html[dir="rtl"] & {
-            margin-left: ($n / $large-column-count) * $container-width !important;
+            margin-left: ($n / $large-column-count) * $container-width - 1 !important;
           }
         }
       }


### PR DESCRIPTION
The pre and post sizing is sometimes slightly too large by fractions of a pixel. In firefox, in some cases this is rounded *up* and the columns break to the next row. 

![701](https://cloud.githubusercontent.com/assets/1031758/20690546/222bc8da-b580-11e6-8087-f393341750e2.gif)

#701

@patrickarlt 