### PR TITLE
Style Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Modified
 - `figcaption` elements no longer have a left border
+- breadcrumbs now pass WCAG 2.0 contrast requirements
+- fixed spacing between breadcrumbs (#726)
 
 ## 1.0.0-rc.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `figcaption` elements no longer have a left border
 - breadcrumbs now pass WCAG 2.0 contrast requirements
 - fixed spacing between breadcrumbs (#726)
+- remove blue active state for top-nav-title (#729)
 
 ## 1.0.0-rc.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - fixed spacing between breadcrumbs (#726)
 - remove blue active state for top-nav-title (#729)
 
+### Fixed
+- inputs with a type `search` now display properly in Safari (#740)
+
 ## 1.0.0-rc.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-rc.1 (Unreleased)
+
+### Modified
+- `figcaption` elements no longer have a left border
+
 ## 1.0.0-rc.0
 
 ### Added

--- a/docs/source/documentation/components/_panels.md
+++ b/docs/source/documentation/components/_panels.md
@@ -1,2 +1,4 @@
-Panels are useful to draw attention or contain certain text on a page. They are simple containers, which can be used to help guide users through the visual hierarchy of your design. Adding borders and padding to any of the panels shown below allows for framing content as a call-out.
+Panels are useful to draw attention or contain certain text on a page. They are simple containers, which can be used to help guide users through the visual hierarchy of your design.
+
+If you use a dark or blue panel color, be sure to use the [link modifier classes](../type/#link-color) to style links in an appropriate color.
 

--- a/docs/source/documentation/components/sample-code/_images.html
+++ b/docs/source/documentation/components/sample-code/_images.html
@@ -1,17 +1,17 @@
-<img srcset="{{relativePath}}/assets/img/illustrations/image-1920-xlg.jpg 192w,
-             {{relativePath}}/assets/img/illustrations/image-960-lg.jpg   960w,
-             {{relativePath}}/assets/img/illustrations/image-480-md.jpg   480w"
-     src="{{relativePath}}/assets/img/illustrations/image.jpg"
+<img srcset="{{relativePath}}/assets/img/docs/image-1920-xlg.jpg 192w,
+             {{relativePath}}/assets/img/docs/image-960-lg.jpg   960w,
+             {{relativePath}}/assets/img/docs/image-480-md.jpg   480w"
+     src="{{relativePath}}/assets/img/docs/image.jpg"
      alt="24 column or fulscreen image.">
 
-<img srcset="{{relativePath}}/assets/img/illustrations/image-960-lg.jpg   960w,
-             {{relativePath}}/assets/img/illustrations/image-480-md.jpg   480w,
-             {{relativePath}}/assets/img/illustrations/image-240-sm.jpg   240w"
-     src="{{relativePath}}/assets/img/illustrations/image.jpg"
+<img srcset="{{relativePath}}/assets/img/docs/image-960-lg.jpg   960w,
+             {{relativePath}}/assets/img/docs/image-480-md.jpg   480w,
+             {{relativePath}}/assets/img/docs/image-240-sm.jpg   240w"
+     src="{{relativePath}}/assets/img/docs/image.jpg"
      alt="12 column or two up image.">
 
-<img srcset="{{relativePath}}/assets/img/illustrations/image-640-bmd.jpg  640w,
-             {{relativePath}}/assets/img/illustrations/image-320-smd.jpg  320w,
-             {{relativePath}}/assets/img/illustrations/image-160-xsm.jpg  160w"
-     src="{{relativePath}}/assets/img/illustrations/image.jpg"
+<img srcset="{{relativePath}}/assets/img/docs/image-640-bmd.jpg  640w,
+             {{relativePath}}/assets/img/docs/image-320-smd.jpg  320w,
+             {{relativePath}}/assets/img/docs/image-160-xsm.jpg  160w"
+     src="{{relativePath}}/assets/img/docs/image.jpg"
      alt="8 column or three up image">

--- a/docs/source/documentation/components/sample-code/_panels.html
+++ b/docs/source/documentation/components/sample-code/_panels.html
@@ -1,4 +1,4 @@
 <div class="panel {{modifier}}">
-  <h4>This is a panel.</h4>
-  <p>Panels set <code>background-color</code> and frame content. Panels also <a href="">style links</a> in a color that can be read on the panel background.</p>
+  <h4 class="trailer-half">This is a panel.</h4>
+  <p class="trailer-0">Panels set <code>background-color</code> and frame content.</p>
 </div>

--- a/lib/img/forward-slash-white.svg
+++ b/lib/img/forward-slash-white.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="5.135px" height="10.478px" viewBox="0 0 5.135 10.478" enable-background="new 0 0 5.135 10.478" xml:space="preserve">
-<g>
-	<path fill="#FFFFFF" d="M1.079,10.478L0,10.088L4.056,0l1.079,0.416L1.079,10.478z"/>
-</g>
-</svg>

--- a/lib/img/forward-slash.svg
+++ b/lib/img/forward-slash.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="5.135px" height="10.478px" viewBox="0 0 5.135 10.478" enable-background="new 0 0 5.135 10.478" xml:space="preserve">
-<g>
-	<path fill="#A9A9A9" d="M1.079,10.478L0,10.088L4.056,0l1.079,0.416L1.079,10.478z"/>
-</g>
-</svg>

--- a/lib/sass/calcite-web/components/_breadcrumbs.scss
+++ b/lib/sass/calcite-web/components/_breadcrumbs.scss
@@ -6,21 +6,20 @@
 
 @mixin breadcrumbs() {
   @include font-size(-2);
-  @include text-color($dark-gray);
+  @include text-color($darker-gray);
 }
 
   @mixin crumb() {
-    color: $dark-gray;
-    padding: 0 0.25rem 0 0.75rem;
-    background: url('#{$image-path}/forward-slash.svg') left center no-repeat transparent;
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        padding: 0 0.75rem 0 0.25rem;
-        background: url('#{$image-path}/forward-slash.svg') right center no-repeat transparent;
-        white-space: nowrap;
-      }
-    }
+    color: $darker-gray;
     @include left();
+
+    &:before {
+      content: "/";
+      color: $darker-gray;
+      font-weight: 400;
+      display: inline-block;
+      padding: 0 .5rem;
+    }
 
     &.is-active {
       font-weight: 600;
@@ -29,22 +28,17 @@
     .breadcrumbs-white & {
       color: white;
       @include link-color($white, $lightest-gray);
-      background-image: url('#{$image-path}/forward-slash-white.svg');
+      &:before {
+        color: white;
+      }
     }
 
-    &:first-child {
-      background-image: none;
-      padding-left: 0;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          padding-right: 0;
-          background: none;
-        }
-      }
+    &:first-child:before {
+      display: none;
     }
   }
 
 @if $include-breadcrumbs == true {
-  .breadcrumbs {@include breadcrumbs();}
-    .crumb {@include crumb();}
+  .breadcrumbs { @include breadcrumbs(); }
+    .crumb { @include crumb(); }
 }

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -60,6 +60,10 @@
     }
   }
 
+  input {
+    -webkit-appearance: none;
+  }
+
   textarea {
     height: auto;
     padding-top: $baseline / 5;
@@ -180,6 +184,12 @@
       border: none;
       outline: auto;
     }
+  }
+  input[type='checkbox'] {
+    -webkit-appearance: checkbox;
+  }
+  input[type='radio'] {
+    -webkit-appearance: radio;
   }
 
   .fieldset-radio, .fieldset-checkbox {

--- a/lib/sass/calcite-web/patterns/_top-nav.scss
+++ b/lib/sass/calcite-web/patterns/_top-nav.scss
@@ -24,9 +24,8 @@
     @include left();
     margin-right: 1.5rem;
     padding-top: 1.125rem;
-    padding-bottom: calc(1.25rem - 4px);
+    padding-bottom: 1.25rem;
     line-height: 1.5rem;
-    border-bottom: 4px solid transparent;
     color: $off-black;
     @if ($include-right-to-left) {
       html[dir="rtl"] & {
@@ -36,8 +35,6 @@
       }
     }
     &:hover {
-      color: $blue;
-      border-bottom-color: $blue;
       text-decoration: none;
     }
   }

--- a/lib/sass/calcite-web/type/_scale.scss
+++ b/lib/sass/calcite-web/type/_scale.scss
@@ -129,16 +129,18 @@
   @else if $n <= 2 {
     line-height: $baseline;
   }
-  @media screen and (max-width: $medium - 1) {
-    font-size: medium-modular-scale($n);
-  }
-  @media screen and (max-width: $small - 1) {
-    font-size: small-modular-scale($n);
-    @if $n > 7 {
-      line-height: 2*$baseline;
+  @if $n > 0 {
+    @media screen and (max-width: $medium - 1) {
+      font-size: medium-modular-scale($n);
     }
-    @else if $n <= 7 and $n > 4 {
-      line-height: 1.5*$baseline;
+    @media screen and (max-width: $small - 1) {
+      font-size: small-modular-scale($n);
+      @if $n > 7 {
+        line-height: 2*$baseline;
+      }
+      @else if $n <= 7 and $n > 4 {
+        line-height: 1.5*$baseline;
+      }
     }
   }
 }

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -16,9 +16,12 @@
     line-height: $baseline;
     color: $type-color;
 
+    -webkit-font-smoothing: subpixel-antialiased;
+
     -webkit-font-feature-settings: "kern";
        -moz-font-feature-settings: "kern";
             font-feature-settings: "kern";
+
     font-kerning: normal;
 
     text-rendering: optimizeLegibility;

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -215,19 +215,9 @@
 
   figcaption {
     margin: $baseline/4 0;
-    padding-left: $baseline/2;
-    border-left: 3px solid $dark-gray;
     @include font-size(-2);
     font-style: italic;
     color: $dark-gray;
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        padding-left: 0;
-        border-left: none;
-        padding-right: $baseline/2;
-        border-right: 3px solid $dark-gray;
-      }
-    }
   }
 
   table {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "url": "https://github.com/esri/calcite-web/issues"
   },
   "devDependencies": {
-    "acetate": "^1.1.1",
+    "acetate": "paulcpederson/acetate#63",
     "acetate-cli": "^1.0.1",
     "babel-preset-es2015-rollup": "^1.2.0",
     "babel-plugin-transform-regenerator": "6.16.1",


### PR DESCRIPTION
- much better implementation for breadcrumbs
- fix 404s in doc
- reduce built CSS size with small optimization to `font-size` mixin
- top-nav-title has no blue underline now on hover/focus
- remove opinionated styles from `figcaption`
- fix `input type="search"` in Safari (broken since `v1.0.0-rc.0`)
- small improvement to text rendering in Safari
