### PR TITLE
Leader/Trailer: Add quarter variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - JS lib now allows for named ES6 exports with `import {drawer} from 'calcite-web/es6'` (#736)
+- Quarter variants for `leader` and `trailer` (#785)
 
 ## 1.0.0-rc.2
 

--- a/dist/css/calcite-web-dark.css
+++ b/dist/css/calcite-web-dark.css
@@ -6495,14 +6495,26 @@ input.filter-dropdown-input {
 .leader-half {
   margin-top: 0.775rem; }
 
+.leader-quarter {
+  margin-top: 0.3875rem; }
+
 .trailer-half {
   margin-bottom: 0.775rem; }
+
+.trailer-quarter {
+  margin-bottom: 0.3875rem; }
 
 .padding-leader-half {
   padding-top: 0.775rem; }
 
+.padding-leader-quarter {
+  padding-top: 0.3875rem; }
+
 .padding-trailer-half {
   padding-bottom: 0.775rem; }
+
+.padding-trailer-quarter {
+  padding-bottom: 0.3875rem; }
 
 .leader-0 {
   margin-top: 0rem; }
@@ -6591,12 +6603,20 @@ input.filter-dropdown-input {
 @media screen and (min-width: 1450px) {
   .large-leader-half {
     margin-top: 0.775rem; }
+  .large-leader-quarter {
+    margin-top: 0.3875rem; }
   .large-trailer-half {
     margin-bottom: 0.775rem; }
+  .large-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .large-padding-leader-half {
     padding-top: 0.775rem; }
+  .large-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .large-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .large-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .large-leader-0 {
     margin-top: 0rem; }
   .large-trailer-0 {
@@ -6657,12 +6677,20 @@ input.filter-dropdown-input {
 @media screen and (max-width: 859px) {
   .tablet-leader-half {
     margin-top: 0.775rem; }
+  .tablet-leader-quarter {
+    margin-top: 0.3875rem; }
   .tablet-trailer-half {
     margin-bottom: 0.775rem; }
+  .tablet-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .tablet-padding-leader-half {
     padding-top: 0.775rem; }
+  .tablet-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .tablet-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .tablet-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .tablet-leader-0 {
     margin-top: 0rem; }
   .tablet-trailer-0 {
@@ -6723,12 +6751,20 @@ input.filter-dropdown-input {
 @media screen and (max-width: 479px) {
   .phone-leader-half {
     margin-top: 0.775rem; }
+  .phone-leader-quarter {
+    margin-top: 0.3875rem; }
   .phone-trailer-half {
     margin-bottom: 0.775rem; }
+  .phone-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .phone-padding-leader-half {
     padding-top: 0.775rem; }
+  .phone-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .phone-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .phone-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .phone-leader-0 {
     margin-top: 0rem; }
   .phone-trailer-0 {

--- a/dist/css/calcite-web-no-fonts.css
+++ b/dist/css/calcite-web-no-fonts.css
@@ -6406,14 +6406,26 @@ input.filter-dropdown-input {
 .leader-half {
   margin-top: 0.775rem; }
 
+.leader-quarter {
+  margin-top: 0.3875rem; }
+
 .trailer-half {
   margin-bottom: 0.775rem; }
+
+.trailer-quarter {
+  margin-bottom: 0.3875rem; }
 
 .padding-leader-half {
   padding-top: 0.775rem; }
 
+.padding-leader-quarter {
+  padding-top: 0.3875rem; }
+
 .padding-trailer-half {
   padding-bottom: 0.775rem; }
+
+.padding-trailer-quarter {
+  padding-bottom: 0.3875rem; }
 
 .leader-0 {
   margin-top: 0rem; }
@@ -6502,12 +6514,20 @@ input.filter-dropdown-input {
 @media screen and (min-width: 1450px) {
   .large-leader-half {
     margin-top: 0.775rem; }
+  .large-leader-quarter {
+    margin-top: 0.3875rem; }
   .large-trailer-half {
     margin-bottom: 0.775rem; }
+  .large-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .large-padding-leader-half {
     padding-top: 0.775rem; }
+  .large-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .large-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .large-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .large-leader-0 {
     margin-top: 0rem; }
   .large-trailer-0 {
@@ -6568,12 +6588,20 @@ input.filter-dropdown-input {
 @media screen and (max-width: 859px) {
   .tablet-leader-half {
     margin-top: 0.775rem; }
+  .tablet-leader-quarter {
+    margin-top: 0.3875rem; }
   .tablet-trailer-half {
     margin-bottom: 0.775rem; }
+  .tablet-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .tablet-padding-leader-half {
     padding-top: 0.775rem; }
+  .tablet-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .tablet-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .tablet-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .tablet-leader-0 {
     margin-top: 0rem; }
   .tablet-trailer-0 {
@@ -6634,12 +6662,20 @@ input.filter-dropdown-input {
 @media screen and (max-width: 479px) {
   .phone-leader-half {
     margin-top: 0.775rem; }
+  .phone-leader-quarter {
+    margin-top: 0.3875rem; }
   .phone-trailer-half {
     margin-bottom: 0.775rem; }
+  .phone-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .phone-padding-leader-half {
     padding-top: 0.775rem; }
+  .phone-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .phone-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .phone-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .phone-leader-0 {
     margin-top: 0rem; }
   .phone-trailer-0 {

--- a/dist/css/calcite-web.css
+++ b/dist/css/calcite-web.css
@@ -6495,14 +6495,26 @@ input.filter-dropdown-input {
 .leader-half {
   margin-top: 0.775rem; }
 
+.leader-quarter {
+  margin-top: 0.3875rem; }
+
 .trailer-half {
   margin-bottom: 0.775rem; }
+
+.trailer-quarter {
+  margin-bottom: 0.3875rem; }
 
 .padding-leader-half {
   padding-top: 0.775rem; }
 
+.padding-leader-quarter {
+  padding-top: 0.3875rem; }
+
 .padding-trailer-half {
   padding-bottom: 0.775rem; }
+
+.padding-trailer-quarter {
+  padding-bottom: 0.3875rem; }
 
 .leader-0 {
   margin-top: 0rem; }
@@ -6591,12 +6603,20 @@ input.filter-dropdown-input {
 @media screen and (min-width: 1450px) {
   .large-leader-half {
     margin-top: 0.775rem; }
+  .large-leader-quarter {
+    margin-top: 0.3875rem; }
   .large-trailer-half {
     margin-bottom: 0.775rem; }
+  .large-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .large-padding-leader-half {
     padding-top: 0.775rem; }
+  .large-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .large-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .large-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .large-leader-0 {
     margin-top: 0rem; }
   .large-trailer-0 {
@@ -6657,12 +6677,20 @@ input.filter-dropdown-input {
 @media screen and (max-width: 859px) {
   .tablet-leader-half {
     margin-top: 0.775rem; }
+  .tablet-leader-quarter {
+    margin-top: 0.3875rem; }
   .tablet-trailer-half {
     margin-bottom: 0.775rem; }
+  .tablet-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .tablet-padding-leader-half {
     padding-top: 0.775rem; }
+  .tablet-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .tablet-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .tablet-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .tablet-leader-0 {
     margin-top: 0rem; }
   .tablet-trailer-0 {
@@ -6723,12 +6751,20 @@ input.filter-dropdown-input {
 @media screen and (max-width: 479px) {
   .phone-leader-half {
     margin-top: 0.775rem; }
+  .phone-leader-quarter {
+    margin-top: 0.3875rem; }
   .phone-trailer-half {
     margin-bottom: 0.775rem; }
+  .phone-trailer-quarter {
+    margin-bottom: 0.3875rem; }
   .phone-padding-leader-half {
     padding-top: 0.775rem; }
+  .phone-padding-leader-quarter {
+    padding-top: 0.3875rem; }
   .phone-padding-trailer-half {
     padding-bottom: 0.775rem; }
+  .phone-padding-trailer-quarter {
+    padding-bottom: 0.3875rem; }
   .phone-leader-0 {
     margin-top: 0rem; }
   .phone-trailer-0 {

--- a/dist/sass/calcite-web/grid/_leader-trailer.scss
+++ b/dist/sass/calcite-web/grid/_leader-trailer.scss
@@ -5,9 +5,13 @@
 //  ↳ grid → _leader-and-trailer.md
 
 @mixin leader-half()  { margin-top:    0.5 * $baseline; }
+@mixin leader-quarter()  { margin-top:    0.25 * $baseline; }
 @mixin trailer-half() { margin-bottom: 0.5 * $baseline; }
+@mixin trailer-quarter() { margin-bottom: 0.25 * $baseline; }
 @mixin padding-leader-half()  { padding-top:    0.5 * $baseline; }
+@mixin padding-leader-quarter()  { padding-top:    0.25 * $baseline; }
 @mixin padding-trailer-half() { padding-bottom: 0.5 * $baseline; }
+@mixin padding-trailer-quarter() { padding-bottom: 0.25 * $baseline; }
 
 @mixin leader($n)          { margin-top:     $n * $baseline; }
 @mixin trailer($n)         { margin-bottom:  $n * $baseline; }
@@ -19,9 +23,13 @@
   @if $fold-grid == true {
     @media screen and (min-width: $large) {
       .#{$large-class}-leader-half          { margin-top:        $baseline / 2; }
+      .#{$large-class}-leader-quarter          { margin-top:        $baseline / 4; }
       .#{$large-class}-trailer-half         { margin-bottom:     $baseline / 2; }
+      .#{$large-class}-trailer-quarter         { margin-bottom:     $baseline / 4; }
       .#{$large-class}-padding-leader-half          { padding-top:        $baseline / 2; }
+      .#{$large-class}-padding-leader-quarter          { padding-top:        $baseline / 4; }
       .#{$large-class}-padding-trailer-half         { padding-bottom:     $baseline / 2; }
+      .#{$large-class}-padding-trailer-quarter         { padding-bottom:     $baseline / 4; }
       @for $i from 0 through $vertical-range {
         .#{$large-class}-leader-#{$i}          { margin-top:     $i * $baseline; }
         .#{$large-class}-trailer-#{$i}         { margin-bottom:  $i * $baseline; }
@@ -33,9 +41,13 @@
     // Medium
     @media screen and (max-width: $medium - 1) {
       .#{$medium-class}-leader-half          { margin-top:        $baseline / 2; }
+      .#{$medium-class}-leader-quarter          { margin-top:        $baseline / 4; }
       .#{$medium-class}-trailer-half         { margin-bottom:     $baseline / 2; }
+      .#{$medium-class}-trailer-quarter         { margin-bottom:     $baseline / 4; }
       .#{$medium-class}-padding-leader-half          { padding-top:        $baseline / 2; }
+      .#{$medium-class}-padding-leader-quarter          { padding-top:        $baseline / 4; }
       .#{$medium-class}-padding-trailer-half         { padding-bottom:     $baseline / 2; }
+      .#{$medium-class}-padding-trailer-quarter         { padding-bottom:     $baseline / 4; }
       @for $i from 0 through $vertical-range {
         .#{$medium-class}-leader-#{$i}          { margin-top:     $i * $baseline; }
         .#{$medium-class}-trailer-#{$i}         { margin-bottom:  $i * $baseline; }
@@ -47,9 +59,13 @@
     // Small
     @media screen and (max-width: $small - 1) {
       .#{$small-class}-leader-half          { margin-top:        $baseline / 2; }
+      .#{$small-class}-leader-quarter          { margin-top:        $baseline / 4; }
       .#{$small-class}-trailer-half         { margin-bottom:     $baseline / 2; }
+      .#{$small-class}-trailer-quarter         { margin-bottom:     $baseline / 4; }
       .#{$small-class}-padding-leader-half          { padding-top:        $baseline / 2; }
+      .#{$small-class}-padding-leader-quarter          { padding-top:        $baseline / 4; }
       .#{$small-class}-padding-trailer-half         { padding-bottom:     $baseline / 2; }
+      .#{$small-class}-padding-trailer-quarter         { padding-bottom:     $baseline / 4; }
       @for $i from 0 through $vertical-range {
         .#{$small-class}-leader-#{$i}          { margin-top:     $i * $baseline; }
         .#{$small-class}-trailer-#{$i}         { margin-bottom:  $i * $baseline; }
@@ -63,9 +79,13 @@
 @if $include-grid == true or $include-leader-trailer == true {
 
   .leader-half  { @include leader-half(); }
+  .leader-quarter  { @include leader-quarter(); }
   .trailer-half { @include trailer-half(); }
+  .trailer-quarter { @include trailer-quarter(); }
   .padding-leader-half  { @include padding-leader-half(); }
+  .padding-leader-quarter  { @include padding-leader-quarter(); }
   .padding-trailer-half { @include padding-trailer-half(); }
+  .padding-trailer-quarter { @include padding-trailer-quarter(); }
 
   @for $i from 0 through $vertical-range {
     .leader-#{$i}          { @include leader($i)          ;}

--- a/docs/source/documentation/grid/_gutter.md
+++ b/docs/source/documentation/grid/_gutter.md
@@ -1,8 +1,8 @@
-Adds padding the the left or right of an element. For example, `<div class="gutter-left-3">` will receive three units of padding on its left side.
+Adds padding the the left or right of an element. For example, `<div class="padding-left-3">` will receive three units of padding on its left side.
 
 Responsive `tablet-` and `phone-` classes are exposed for defining gutter and gutter behavior on breakpoints.
 
-**Note:** While a single DOM element *can* have both gutter-left and gutter-right helpers, putting both on a single node can cause problems when switching a layout for right to left languages.
+**Note:** While a single DOM element *can* have both padding-left and padding-right helpers, putting both on a single node can cause problems when switching a layout for right to left languages.
 
-If problems occur in a layout, use the `rtl-` prefix to explicitly assign `gutter` classes to the right to left layout.
+If problems occur in a layout, use the `rtl-` prefix to explicitly assign `padding` classes to the right to left layout.
 

--- a/docs/source/table_of_contents.yml
+++ b/docs/source/table_of_contents.yml
@@ -133,6 +133,8 @@ grid:
           link: leader-and-trailer
           modifiers:
             - leader-0
+            - leader-quarter
+            - leader-half
             - leader-1
             - leader-2
             - leader-3
@@ -140,6 +142,8 @@ grid:
             - leader-5
             - leader-6
             - trailer-0
+            - trailer-quarter
+            - trailer-half
             - trailer-1
             - trailer-2
             - trailer-3
@@ -147,6 +151,8 @@ grid:
             - trailer-5
             - trailer-6
             - padding-leader-0
+            - padding-leader-quarter
+            - padding-leader-half
             - padding-leader-1
             - padding-leader-2
             - padding-leader-3
@@ -154,6 +160,8 @@ grid:
             - padding-leader-5
             - padding-leader-6
             - padding-trailer-0
+            - padding-trailer-quarter
+            - padding-trailer-half
             - padding-trailer-1
             - padding-trailer-2
             - padding-trailer-3

--- a/lib/sass/calcite-web/grid/_leader-trailer.scss
+++ b/lib/sass/calcite-web/grid/_leader-trailer.scss
@@ -5,9 +5,13 @@
 //  ↳ grid → _leader-and-trailer.md
 
 @mixin leader-half()  { margin-top:    0.5 * $baseline; }
+@mixin leader-quarter()  { margin-top:    0.25 * $baseline; }
 @mixin trailer-half() { margin-bottom: 0.5 * $baseline; }
+@mixin trailer-quarter() { margin-bottom: 0.25 * $baseline; }
 @mixin padding-leader-half()  { padding-top:    0.5 * $baseline; }
+@mixin padding-leader-quarter()  { padding-top:    0.25 * $baseline; }
 @mixin padding-trailer-half() { padding-bottom: 0.5 * $baseline; }
+@mixin padding-trailer-quarter() { padding-bottom: 0.25 * $baseline; }
 
 @mixin leader($n)          { margin-top:     $n * $baseline; }
 @mixin trailer($n)         { margin-bottom:  $n * $baseline; }
@@ -19,9 +23,13 @@
   @if $fold-grid == true {
     @media screen and (min-width: $large) {
       .#{$large-class}-leader-half          { margin-top:        $baseline / 2; }
+      .#{$large-class}-leader-quarter          { margin-top:        $baseline / 4; }
       .#{$large-class}-trailer-half         { margin-bottom:     $baseline / 2; }
+      .#{$large-class}-trailer-quarter         { margin-bottom:     $baseline / 4; }
       .#{$large-class}-padding-leader-half          { padding-top:        $baseline / 2; }
+      .#{$large-class}-padding-leader-quarter          { padding-top:        $baseline / 4; }
       .#{$large-class}-padding-trailer-half         { padding-bottom:     $baseline / 2; }
+      .#{$large-class}-padding-trailer-quarter         { padding-bottom:     $baseline / 4; }
       @for $i from 0 through $vertical-range {
         .#{$large-class}-leader-#{$i}          { margin-top:     $i * $baseline; }
         .#{$large-class}-trailer-#{$i}         { margin-bottom:  $i * $baseline; }
@@ -33,9 +41,13 @@
     // Medium
     @media screen and (max-width: $medium - 1) {
       .#{$medium-class}-leader-half          { margin-top:        $baseline / 2; }
+      .#{$medium-class}-leader-quarter          { margin-top:        $baseline / 4; }
       .#{$medium-class}-trailer-half         { margin-bottom:     $baseline / 2; }
+      .#{$medium-class}-trailer-quarter         { margin-bottom:     $baseline / 4; }
       .#{$medium-class}-padding-leader-half          { padding-top:        $baseline / 2; }
+      .#{$medium-class}-padding-leader-quarter          { padding-top:        $baseline / 4; }
       .#{$medium-class}-padding-trailer-half         { padding-bottom:     $baseline / 2; }
+      .#{$medium-class}-padding-trailer-quarter         { padding-bottom:     $baseline / 4; }
       @for $i from 0 through $vertical-range {
         .#{$medium-class}-leader-#{$i}          { margin-top:     $i * $baseline; }
         .#{$medium-class}-trailer-#{$i}         { margin-bottom:  $i * $baseline; }
@@ -47,9 +59,13 @@
     // Small
     @media screen and (max-width: $small - 1) {
       .#{$small-class}-leader-half          { margin-top:        $baseline / 2; }
+      .#{$small-class}-leader-quarter          { margin-top:        $baseline / 4; }
       .#{$small-class}-trailer-half         { margin-bottom:     $baseline / 2; }
+      .#{$small-class}-trailer-quarter         { margin-bottom:     $baseline / 4; }
       .#{$small-class}-padding-leader-half          { padding-top:        $baseline / 2; }
+      .#{$small-class}-padding-leader-quarter          { padding-top:        $baseline / 4; }
       .#{$small-class}-padding-trailer-half         { padding-bottom:     $baseline / 2; }
+      .#{$small-class}-padding-trailer-quarter         { padding-bottom:     $baseline / 4; }
       @for $i from 0 through $vertical-range {
         .#{$small-class}-leader-#{$i}          { margin-top:     $i * $baseline; }
         .#{$small-class}-trailer-#{$i}         { margin-bottom:  $i * $baseline; }
@@ -63,9 +79,13 @@
 @if $include-grid == true or $include-leader-trailer == true {
 
   .leader-half  { @include leader-half(); }
+  .leader-quarter  { @include leader-quarter(); }
   .trailer-half { @include trailer-half(); }
+  .trailer-quarter { @include trailer-quarter(); }
   .padding-leader-half  { @include padding-leader-half(); }
+  .padding-leader-quarter  { @include padding-leader-quarter(); }
   .padding-trailer-half { @include padding-trailer-half(); }
+  .padding-trailer-quarter { @include padding-trailer-quarter(); }
 
   @for $i from 0 through $vertical-range {
     .leader-#{$i}          { @include leader($i)          ;}


### PR DESCRIPTION
## Leader/Trailer: Quarter variants
Mixins and classes for adding top or bottom margin or padding that is 25% of `$baseline`.

### New Mixins
- `leader-quarter()`
- `trailer-quarter()`
- `padding-leader-quarter()`
- `padding-trailer-quarter()`

### New Classes
- `.leader-quarter`
- `.trailer-quarter`
- `.padding-leader-quarter`
- `.padding-leader-quarter`
- `.large-leader-quarter`
- `.large-trailer-quarter`
- `.large-padding-leader-quarter`
- `.large-padding-leader-quarter`
- `.tablet-leader-quarter`
- `.tablet-trailer-quarter`
- `.tablet-padding-leader-quarter`
- `.tablet-padding-leader-quarter`
- `.phone-leader-quarter`
- `.phone-trailer-quarter`
- `.phone-padding-leader-quarter`
- `.phone-padding-leader-quarter`

### Misc.
Updated Gutter docs. No more classes named `gutter-`.
