### PR TITLE
remove esri tags from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
 
-[](Esri Tags: Calcite CSS Sass Web Framework JavaScript)
-[](Esri Language: CSS)
-
-
-


### PR DESCRIPTION
custom markdown tags are no longer hidden.

in `v2` of esri.github.io we'll be showcasing this project and relying on some new canned [`topics`](https://github.com/blog/2309-introducing-topics)

at a minimum, can you add `web-development` as one please?