### PR TITLE
fix for broken thumbnails

### DIFF
--- a/docs/source/examples/core/_features.html
+++ b/docs/source/examples/core/_features.html
@@ -6,15 +6,15 @@
     <h2 class="text-center">What is a Geotrigger Action?</h2>
     <div class="block-group block-group-3-up tablet-block-group-1-up trailer-1">
       <div class="block text-center trailer-1 leader-1">
-        <img src="http://www.developers.arcgis.com/assets/img/features/geotriggers-service/action-1.jpg" alt="Send push notification to phone" class="trailer-1">
+        <img src="http://webhelp.esri.com/arcgisexplorer/1500/gpsicons/GPX_95_cemetery.png" alt="Send push notification to phone" class="trailer-1">
         <h4>Sending a push notification to a phone.</h4>
       </div>
       <div class="block text-center trailer-1 leader-1">
-        <img src="http://www.developers.arcgis.com/assets/img/features/geotriggers-service/action-2.jpg" alt="Send an action to a server" class="trailer-1">
+        <img src="http://webhelp.esri.com/arcgisexplorer/1500/gpsicons/GPX_95_cemetery.png" alt="Send an action to a server" class="trailer-1">
         <h4>Sending an action to a server.</h4>
       </div>
       <div class="block text-center trailer-1 leader-1">
-        <img src="http://www.developers.arcgis.com/assets/img/features/geotriggers-service/action-3.jpg" alt="Send an action to an app" class="trailer-1">
+        <img src="http://webhelp.esri.com/arcgisexplorer/1500/gpsicons/GPX_95_cemetery.png" alt="Send an action to an app" class="trailer-1">
         <h4>Sending an action to an app.</h4>
       </div>
     </div>


### PR DESCRIPTION
... down at the bottom of [/examples/core/](http://esri.github.io/calcite-web/examples/core/)