### PR TITLE
Simplify font stack

### DIFF
--- a/dist/sass/calcite-web/type/_config.scss
+++ b/dist/sass/calcite-web/type/_config.scss
@@ -30,9 +30,9 @@ $indent:             1em;
 
 // Header Family
 $avenir-tracking:    0;
-$avenir-family:      'Avenir Next W01', 'Avenir Next W00', 'Avenir Next', 'Avenir', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+$avenir-family:      'Avenir Next', 'Helvetica Neue', sans-serif;
 
 // Code Family
 $code-tracking:      0;
-$code-family:        'Consolas', 'Andale Mono', 'Lucida Console', 'Monaco', 'Courier New', Courier, monospace;
+$code-family:        'Consolas', 'Andale Mono', 'Lucida Console', 'Monaco', monospace;
 


### PR DESCRIPTION
#### Summary of changes:

- Removes 5 fallbacks from `$avenir-family`.
- Removes 2 fallbacks from `$code-family`.

#### Rationale:

- `Avenir Next W01` and `Avenir Next W00` are no longer available.
- `Helvetica` and `Arial` are already the default sans-serif fonts on
their respective operating systems.
- `Courier New` and `Courier` are already the default sans-serif fonts
on their respective operating systems.

See:
https://www.granneman.com/webdev/coding/css/fonts-and-formatting/web-bro
wser-font-defaults/

#### Questions

- Should `Avenir` be used as a fallback? Are there situations where it should be used and Avenir Next will not be available?