### PR TITLE
Sass: Correct all documentation links

### DIFF
--- a/dist/sass/calcite-web/base/_config.scss
+++ b/dist/sass/calcite-web/base/_config.scss
@@ -1,7 +1,7 @@
 // ┌──────────────┐
 // │ UI Variables │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#ui-variables
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#ui-variables
 //  ↳ sass → _ui-variables.md
 $transition:               150ms linear                !default;
 $box-shadow:               0 0 16px 0 rgba(0,0,0,.05)  !default;
@@ -18,7 +18,7 @@ $link-hover:               $dark-blue                  !default;
 // ┌──────────────┐
 // │ Breakpoints  │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#breakpoints
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#breakpoints
 //  ↳ sass → _breakpoints.md
 $small:                    480px                       !default;
 $medium:                   860px                       !default;
@@ -27,7 +27,7 @@ $large:                    1450px                      !default;
 // ┌────────────────────┐
 // │ Grid Configuration │
 // └────────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#configuration
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#configuration
 //  ↳ grid → _configuration.md
 $prefix:                   ""                          !default;
 

--- a/dist/sass/calcite-web/components/_alert.scss
+++ b/dist/sass/calcite-web/components/_alert.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Alerts │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#alerts
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#alerts
 //  ↳ components → _alerts.md
 
 @mixin alert() {

--- a/dist/sass/calcite-web/components/_animation.scss
+++ b/dist/sass/calcite-web/components/_animation.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Animations │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#animation
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#animation
 //  ↳ component → _animation.md
 
 @mixin fade-in () {

--- a/dist/sass/calcite-web/components/_breadcrumbs.scss
+++ b/dist/sass/calcite-web/components/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 // ┌─────────────┐
 // │ Breadcrumbs │
 // └─────────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#breadcrumbs
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#breadcrumbs
 //  ↳ components → _breadbrumbs.md
 
 @mixin breadcrumbs() {

--- a/dist/sass/calcite-web/components/_button.scss
+++ b/dist/sass/calcite-web/components/_button.scss
@@ -1,7 +1,7 @@
 // ┌─────────┐
 // │ Buttons │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#buttons
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#buttons
 //  ↳ components → _buttons.md
 
 @mixin btn() {

--- a/dist/sass/calcite-web/components/_dropdown.scss
+++ b/dist/sass/calcite-web/components/_dropdown.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Dropdowns │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#dropdowns
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#dropdowns
 //  ↳ components → _dropdowns.md
 
 @mixin dropdown {

--- a/dist/sass/calcite-web/components/_esri-logo.scss
+++ b/dist/sass/calcite-web/components/_esri-logo.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Esri Logo │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#esri-logo
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#esri-logo
 //  ↳ components → _esri-logo.md
 @mixin esri-logo() {
   margin: $baseline/4;

--- a/dist/sass/calcite-web/components/_form.scss
+++ b/dist/sass/calcite-web/components/_form.scss
@@ -27,7 +27,7 @@
   // ┌───────┐
   // │ Forms │
   // └───────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#form-overview
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#form-overview
   //  ↳ components → _form-overview.md
   form {
     margin: 0;
@@ -103,7 +103,7 @@
   // ┌─────────────┐
   // │ Text Inputs │
   // └─────────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#text-inputs
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#text-inputs
   //  ↳ components → _text-inputs.md
 
   .input-search {
@@ -117,7 +117,7 @@
   // ┌─────────────────┐
   // │ Form Validation │
   // └─────────────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#form-validation
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#form-validation
   //  ↳ components → _form-validation.md
   .input-error {
     border-color: $Calcite_Red_200;
@@ -202,8 +202,8 @@
   // ┌────────────────────────────┐
   // │ Checkboxes & Radio Buttons │
   // └────────────────────────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#checkboxes
-  //  ↳ http://esri.github.io/calcite-web/components/#radio-buttons
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#checkboxes
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#radio-buttons
   //  ↳ components → _checkboxes.md
   //  ↳ components → _radio-buttons.md
   input[type='radio'], input[type='checkbox'] {
@@ -246,7 +246,7 @@
   // ┌─────────┐
   // │ Selects │
   // └─────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#selects
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#selects
   //  ↳ components → _selects.md
   select {
     background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNi4wLjQsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iMTAwcHgiIGhlaWdodD0iMTAwcHgiIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxnPg0KCTxwYXRoIGZpbGw9IiM1OTU5NTkiIGQ9Ik03NS43NDksMzcuNDY2YzAuNDI1LDAuNDI1LDAuNTUyLDEuMDYzLDAuMzIyLDEuNjE4Qzc1Ljg0MSwzOS42MzksNzUuMzAxLDQwLDc0LjY5OSw0MGgtNDkuNA0KCQljLTAuNiwwLTEuMTQzLTAuMzYyLTEuMzcyLTAuOTE3Yy0wLjIzLTAuNTU1LTAuMTAzLTEuMTkzLDAuMzIyLTEuNjE4bDIzLjQ0LTIzLjQ0YzEuMjc2LTEuMjc2LDMuMzQzLTEuMjc2LDQuNjIsMEw3NS43NDksMzcuNDY2DQoJCUw3NS43NDksMzcuNDY2eiBNMjQuMjUsNjIuNTM0Yy0wLjQyNi0wLjQyNS0wLjU1My0xLjA2My0wLjMyMy0xLjYxOGMwLjIzLTAuNTU1LDAuNzctMC45MTYsMS4zNy0wLjkxNkg3NC43DQoJCWMwLjYwMiwwLDEuMTQzLDAuMzU5LDEuMzczLDAuOTE2YzAuMjMsMC41NTUsMC4xMDMsMS4xOTMtMC4zMjIsMS42MThMNTIuMzEsODUuOTc3Yy0xLjI3NSwxLjI3NS0zLjM0NCwxLjI3NC00LjYyLDBMMjQuMjUsNjIuNTM0eg0KCQkiLz4NCjwvZz4NCjwvc3ZnPg0K');

--- a/dist/sass/calcite-web/components/_label.scss
+++ b/dist/sass/calcite-web/components/_label.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Label  │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#label
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#label
 //  ↳ components → _label.md
 
 @mixin label() {

--- a/dist/sass/calcite-web/components/_loader.scss
+++ b/dist/sass/calcite-web/components/_loader.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Loader │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#loader
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#loader
 //  ↳ components → _loader.md
 
 $loader-width: 0.85rem;

--- a/dist/sass/calcite-web/components/_panel.scss
+++ b/dist/sass/calcite-web/components/_panel.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Panels │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#panels
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#panels
 //  ↳ components → _panels.md
 
 @mixin panel() {

--- a/dist/sass/calcite-web/components/_table.scss
+++ b/dist/sass/calcite-web/components/_table.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Tables │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#tables
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#tables
 //  ↳ components → _tables.md
 @mixin table() {
   width: 100%;

--- a/dist/sass/calcite-web/components/_tooltip.scss
+++ b/dist/sass/calcite-web/components/_tooltip.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Tooltips │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#tooltips
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#tooltips
 //  ↳ components → _tooltips.md
 @if $include-tooltip {
   $multiline-max-width: 250px;

--- a/dist/sass/calcite-web/grid/_block-groups.scss
+++ b/dist/sass/calcite-web/grid/_block-groups.scss
@@ -1,7 +1,7 @@
 // ┌──────────────┐
 // │ Block Groups │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#block-groups
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#block-groups
 //  ↳ grid → _block-groups.md
 
 $half-gutter: 0.75 * $column-gutter;
@@ -81,7 +81,7 @@ $full-gutter: $half-gutter * 2;
 // ┌─────────────────────────┐
 // │ Responsive Block Groups │
 // └─────────────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#responsive-block-groups
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#responsive-block-groups
 //  ↳ grid → _responsive-block-groups.md
 @if $block-grid == true {
   @include respond-to($medium) {

--- a/dist/sass/calcite-web/grid/_columns.scss
+++ b/dist/sass/calcite-web/grid/_columns.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Container │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#container
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#container
 //  ↳ grid → _container.md
 
 @mixin grid-container() {
@@ -18,7 +18,7 @@
 // ┌─────────┐
 // │ Columns │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#columns
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#columns
 //  ↳ grid → _columns.md
 
 %column {
@@ -55,7 +55,7 @@
 // ┌────────────────┐
 // │ First and Last │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#first-and-last
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#first-and-last
 //  ↳ grid → _first-and-last.md
 
 @mixin first-column() {
@@ -81,7 +81,7 @@
 // ┌────────────────────┐
 // │ Responsive Columns │
 // └────────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#responsive-columns
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#responsive-columns
 //  ↳ grid → _responsive-columns.md
 
 @mixin responsive-column() {

--- a/dist/sass/calcite-web/grid/_grid.scss
+++ b/dist/sass/calcite-web/grid/_grid.scss
@@ -1,7 +1,7 @@
 // ┌──────┐
 // │ Grid │
 // └──────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#overview
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#overview
 //  ↳ grid → _overview.md
 @import "mixins";
 @import "columns";

--- a/dist/sass/calcite-web/grid/_gutter.scss
+++ b/dist/sass/calcite-web/grid/_gutter.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Gutter │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#gutter
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#gutter
 //  ↳ grid → _gutter.md
 
 @mixin gutter-left-quarter() {

--- a/dist/sass/calcite-web/grid/_leader-trailer.scss
+++ b/dist/sass/calcite-web/grid/_leader-trailer.scss
@@ -1,7 +1,7 @@
 // ┌────────────────┐
 // │ Leader Trailer │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#leader-and-trailer
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#leader-and-trailer
 //  ↳ grid → _leader-and-trailer.md
 
 @mixin leader-half()  { margin-top:    0.5 * $baseline; }

--- a/dist/sass/calcite-web/grid/_left-right.scss
+++ b/dist/sass/calcite-web/grid/_left-right.scss
@@ -1,7 +1,7 @@
 // ┌────────────────┐
 // │ Left and Right │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#left-and-right
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#left-and-right
 //  ↳ grid → _left-and-right.md
 
 @mixin include-left-right(){

--- a/dist/sass/calcite-web/grid/_pre-post.scss
+++ b/dist/sass/calcite-web/grid/_pre-post.scss
@@ -1,7 +1,7 @@
 // ┌──────────────┐
 // │ Pre and Post │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#pre-and-post
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#pre-and-post
 //  ↳ grid → _pre-and-post.md
 
 @mixin responsive-pre-post(){

--- a/dist/sass/calcite-web/grid/_show-hide.scss
+++ b/dist/sass/calcite-web/grid/_show-hide.scss
@@ -1,7 +1,7 @@
 // ┌───────────────┐
 // │ Show and Hide │
 // └───────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#show-and-hide
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#show-and-hide
 //  ↳ grid → _show-and-hide.md
 
 // Responsive Show and Hide

--- a/dist/sass/calcite-web/icons/_icon-colors.scss
+++ b/dist/sass/calcite-web/icons/_icon-colors.scss
@@ -1,7 +1,7 @@
 // ┌──────────────────┐
 // │ Icon Font Colors │
 // └──────────────────┘
-//  ↳ http://esri.github.io/calcite-web/icons/#icon-font-colors
+//  ↳ http://esri.github.io/calcite-web/documenation/icons/#icon-font-colors
 //  ↳ icons → _icon-font.md
 
 @if $include-icon-font == true {

--- a/dist/sass/calcite-web/patterns/_accordion.scss
+++ b/dist/sass/calcite-web/patterns/_accordion.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Accordion │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#accordion
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#accordion
 //  ↳ patterns → _accordion.md
 
 @mixin accordion() {

--- a/dist/sass/calcite-web/patterns/_drawers.scss
+++ b/dist/sass/calcite-web/patterns/_drawers.scss
@@ -1,7 +1,7 @@
 // ┌─────────┐
 // │ Drawers │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#drawers
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#drawers
 //  ↳ patterns → _drawers.md
 
 $transform-transition: transform 200ms cubic-bezier(0.215, 0.440, 0.420, 0.880);

--- a/dist/sass/calcite-web/patterns/_filter-dropdown.scss
+++ b/dist/sass/calcite-web/patterns/_filter-dropdown.scss
@@ -1,7 +1,7 @@
 // ┌─────────────────┐
 // │ Filter Dropdown │
 // └─────────────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#filter-dropdown
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#filter-dropdown
 //  ↳ patterns → _filter-dropdown.md
 
 @mixin filter-dropdown-input() {

--- a/dist/sass/calcite-web/patterns/_footer.scss
+++ b/dist/sass/calcite-web/patterns/_footer.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Footer │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#footer
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#footer
 //  ↳ patterns → _footer.md
 @if $include-sticky-footer == true {
   body {

--- a/dist/sass/calcite-web/patterns/_modal.scss
+++ b/dist/sass/calcite-web/patterns/_modal.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Modals │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#modals
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#modals
 //  ↳ patterns → _modals.md
 
 @mixin modal-overlay() {

--- a/dist/sass/calcite-web/patterns/_search.scss
+++ b/dist/sass/calcite-web/patterns/_search.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Search │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#search
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#search
 //  ↳ patterns → _search.md
 
 @mixin search-overlay() {

--- a/dist/sass/calcite-web/patterns/_side-nav.scss
+++ b/dist/sass/calcite-web/patterns/_side-nav.scss
@@ -1,7 +1,7 @@
 // ┌─────────┐
 // │ Sidenav │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#side-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#side-nav
 //  ↳ patterns → _side-nav.md
 
 @mixin side-nav() {

--- a/dist/sass/calcite-web/patterns/_sub-nav.scss
+++ b/dist/sass/calcite-web/patterns/_sub-nav.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Subnav │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#sub-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#sub-nav
 //  ↳ patterns → _sub-nav.md
 $subnav-link-underline: linear-gradient(to top, transparent 94%, $white 96%, $white 100%);
 

--- a/dist/sass/calcite-web/patterns/_tabs.scss
+++ b/dist/sass/calcite-web/patterns/_tabs.scss
@@ -1,7 +1,7 @@
 // ┌──────┐
 // │ Tabs │
 // └──────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#tabs
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#tabs
 //  ↳ patterns → _tabs.md
 
 @mixin tab-nav(){

--- a/dist/sass/calcite-web/patterns/_third-nav.scss
+++ b/dist/sass/calcite-web/patterns/_third-nav.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Thirdnav │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#third-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#third-nav
 //  ↳ patterns → _third-nav.md
 
 @mixin third-nav() {

--- a/dist/sass/calcite-web/patterns/_top-nav.scss
+++ b/dist/sass/calcite-web/patterns/_top-nav.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Topnav │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#top-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#top-nav
 //  ↳ patterns → _top-nav.md
 @mixin top-nav {
   position: relative;

--- a/dist/sass/calcite-web/patterns/_user-nav.scss
+++ b/dist/sass/calcite-web/patterns/_user-nav.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Modals │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#user-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#user-nav
 //  ↳ patterns → _user-nav.md
 
 @mixin user-name () {

--- a/dist/sass/calcite-web/type/_faces.scss
+++ b/dist/sass/calcite-web/type/_faces.scss
@@ -1,7 +1,7 @@
 // ┌─────────────┐
 // │ Header Face │
 // └─────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#avenir-regular
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#avenir-regular
 //  ↳ type → _avenir-regular.md
 
 @mixin avenir-light() {
@@ -48,7 +48,7 @@
 // ┌───────────┐
 // │ Code Face │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#code-face
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#code-face
 //  ↳ type → _code-face.md
 
 @mixin code-face() {

--- a/dist/sass/calcite-web/type/_mixins.scss
+++ b/dist/sass/calcite-web/type/_mixins.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Tracking │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#tracking
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#tracking
 //  ↳ sass → _tracking.md
 
 @mixin tracking($n) {
@@ -11,7 +11,7 @@
 // ┌─────────┐
 // │ Leading │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#leading
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#leading
 //  ↳ sass → _leading.md
 
 @mixin leading($n) {
@@ -21,7 +21,7 @@
 // ┌──────────────┐
 // │ Word Spacing │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#word-spacing
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#word-spacing
 //  ↳ sass → _word-spacing.md
 
 @mixin word-spacing($n) {
@@ -31,7 +31,7 @@
 // ┌────────────────┐
 // │ Text Modifiers │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#text-modifiers
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#text-modifiers
 //  ↳ type → _text-modifiers.md
 
 @mixin text-inline() {
@@ -88,7 +88,7 @@
 // ┌────────────┐
 // │ List Plain │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#list-plain
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#list-plain
 //  ↳ type → _list-plain.md
 
 @mixin list-plain() {
@@ -102,7 +102,7 @@
 // ┌───────────────┐
 // │ List Numbered │
 // └───────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#list-numbered
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#list-numbered
 //  ↳ type → _list-numbered.md
 
 @mixin list-numbered() {
@@ -171,7 +171,7 @@
 // ┌────────────┐
 // │ Text Color │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#text-color
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#text-color
 //  ↳ type → _text-color.md
 
 @mixin text-color($value) {
@@ -181,7 +181,7 @@
 // ┌────────────┐
 // │ Link Color │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#link-color
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#link-color
 //  ↳ type → _link-color.md
 
 @mixin link-color($value, $light-value) {

--- a/dist/sass/calcite-web/type/_scale.scss
+++ b/dist/sass/calcite-web/type/_scale.scss
@@ -1,7 +1,7 @@
 // ┌───────────────┐
 // │ Modular Scale │
 // └───────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#modular-scale
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#modular-scale
 //  ↳ sass → _modular-scale.md
 @function modular-scale($increment) {
   $v1: $body-size;
@@ -112,7 +112,7 @@
 // ┌───────────┐
 // │ Font Size │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#font-size
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#font-size
 //  ↳ sass → _font-size.md
 
 @mixin font-size($n) {

--- a/dist/sass/calcite-web/utils/_animation.scss
+++ b/dist/sass/calcite-web/utils/_animation.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Animation │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#animation
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#animation
 //  ↳ components → _utility-mixins.md
 
 @mixin animation ($animations...) {

--- a/dist/sass/calcite-web/utils/_appearance.scss
+++ b/dist/sass/calcite-web/utils/_appearance.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Appearance │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#appearance
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#appearance
 //  ↳ components → _utility-mixins.md
 
 @mixin appearance ($value) {

--- a/dist/sass/calcite-web/utils/_box-shadow.scss
+++ b/dist/sass/calcite-web/utils/_box-shadow.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Box Shadow │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#box-shadow
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#box-shadow
 //  ↳ components → _utility-mixins.md
 
 @mixin box-shadow ($shadow) {

--- a/dist/sass/calcite-web/utils/_box-sizing.scss
+++ b/dist/sass/calcite-web/utils/_box-sizing.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Box Sizing │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#box-sizing
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#box-sizing
 //  ↳ components → _utility-mixins.md
 
 @mixin box-sizing ($box) {

--- a/dist/sass/calcite-web/utils/_calc.scss
+++ b/dist/sass/calcite-web/utils/_calc.scss
@@ -1,7 +1,7 @@
 // ┌──────┐
 // │ Calc │
 // └──────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#calc
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#calc
 //  ↳ components → _utility-mixins.md
 
 @mixin calc($property, $value) {

--- a/dist/sass/calcite-web/utils/_clearfix.scss
+++ b/dist/sass/calcite-web/utils/_clearfix.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Clearfix │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#clearfix
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#clearfix
 //  ↳ components → _utility-mixins.md
 
 @mixin clearfix() {

--- a/dist/sass/calcite-web/utils/_inline.scss
+++ b/dist/sass/calcite-web/utils/_inline.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Inline │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#inline-block
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#inline-block
 //  ↳ grid → _inline-block.md
 
 @mixin inline-block() {

--- a/dist/sass/calcite-web/utils/_keyframes.scss
+++ b/dist/sass/calcite-web/utils/_keyframes.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Keyframes │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#keyframes
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#keyframes
 //  ↳ components → _utility-mixins.md
 
 @mixin keyframes ($name) {

--- a/dist/sass/calcite-web/utils/_prefixer.scss
+++ b/dist/sass/calcite-web/utils/_prefixer.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Prefixer │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#prefixer
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#prefixer
 //  ↳ components → _utility-mixins.md
 
 $prefix-for-webkit:    true !default;

--- a/dist/sass/calcite-web/utils/_responsive.scss
+++ b/dist/sass/calcite-web/utils/_responsive.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Respond-To │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#respond-to
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#respond-to
 //  ↳ components → _utility-mixins.md
 
 @mixin respond-to($max: null, $min: null, $type: screen) {

--- a/dist/sass/calcite-web/utils/_transform.scss
+++ b/dist/sass/calcite-web/utils/_transform.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Transform │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#transform
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#transform
 //  ↳ components → _utility-mixins.md
 
 @mixin transform($property: none) {

--- a/dist/sass/calcite-web/utils/_transition.scss
+++ b/dist/sass/calcite-web/utils/_transition.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Transition │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#transition
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#transition
 //  ↳ components → _utility-mixins.md
 
 $transition-prefixes: webkit spec;

--- a/dist/sass/calcite-web/utils/_utils.scss
+++ b/dist/sass/calcite-web/utils/_utils.scss
@@ -1,7 +1,7 @@
 // ┌────────────────┐
 // │ Utility Mixins │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#utility-mixins
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#utility-mixins
 //  ↳ components → _utility-mixins.md
 @import "animation";
 @import "appearance";

--- a/dist/sass/calcite-web/utils/_visibility.scss
+++ b/dist/sass/calcite-web/utils/_visibility.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Visibility │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#visibility
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#visibility
 //  ↳ sass → _utility-mixins.md
 
 // Hide

--- a/lib/sass/calcite-web/base/_config.scss
+++ b/lib/sass/calcite-web/base/_config.scss
@@ -1,7 +1,7 @@
 // ┌──────────────┐
 // │ UI Variables │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#ui-variables
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#ui-variables
 //  ↳ sass → _ui-variables.md
 $transition:               150ms linear                !default;
 $box-shadow:               0 0 16px 0 rgba(0,0,0,.05)  !default;
@@ -18,7 +18,7 @@ $link-hover:               $dark-blue                  !default;
 // ┌──────────────┐
 // │ Breakpoints  │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#breakpoints
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#breakpoints
 //  ↳ sass → _breakpoints.md
 $small:                    480px                       !default;
 $medium:                   860px                       !default;
@@ -27,7 +27,7 @@ $large:                    1450px                      !default;
 // ┌────────────────────┐
 // │ Grid Configuration │
 // └────────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#configuration
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#configuration
 //  ↳ grid → _configuration.md
 $prefix:                   ""                          !default;
 

--- a/lib/sass/calcite-web/components/_alert.scss
+++ b/lib/sass/calcite-web/components/_alert.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Alerts │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#alerts
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#alerts
 //  ↳ components → _alerts.md
 
 @mixin alert() {

--- a/lib/sass/calcite-web/components/_animation.scss
+++ b/lib/sass/calcite-web/components/_animation.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Animations │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#animation
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#animation
 //  ↳ component → _animation.md
 
 @mixin fade-in () {

--- a/lib/sass/calcite-web/components/_breadcrumbs.scss
+++ b/lib/sass/calcite-web/components/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 // ┌─────────────┐
 // │ Breadcrumbs │
 // └─────────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#breadcrumbs
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#breadcrumbs
 //  ↳ components → _breadbrumbs.md
 
 @mixin breadcrumbs() {

--- a/lib/sass/calcite-web/components/_button.scss
+++ b/lib/sass/calcite-web/components/_button.scss
@@ -1,7 +1,7 @@
 // ┌─────────┐
 // │ Buttons │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#buttons
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#buttons
 //  ↳ components → _buttons.md
 
 @mixin btn() {

--- a/lib/sass/calcite-web/components/_dropdown.scss
+++ b/lib/sass/calcite-web/components/_dropdown.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Dropdowns │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#dropdowns
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#dropdowns
 //  ↳ components → _dropdowns.md
 
 @mixin dropdown {

--- a/lib/sass/calcite-web/components/_esri-logo.scss
+++ b/lib/sass/calcite-web/components/_esri-logo.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Esri Logo │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#esri-logo
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#esri-logo
 //  ↳ components → _esri-logo.md
 @mixin esri-logo() {
   margin: $baseline/4;

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -27,7 +27,7 @@
   // ┌───────┐
   // │ Forms │
   // └───────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#form-overview
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#form-overview
   //  ↳ components → _form-overview.md
   form {
     margin: 0;
@@ -103,7 +103,7 @@
   // ┌─────────────┐
   // │ Text Inputs │
   // └─────────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#text-inputs
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#text-inputs
   //  ↳ components → _text-inputs.md
 
   .input-search {
@@ -117,7 +117,7 @@
   // ┌─────────────────┐
   // │ Form Validation │
   // └─────────────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#form-validation
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#form-validation
   //  ↳ components → _form-validation.md
   .input-error {
     border-color: $Calcite_Red_200;
@@ -202,8 +202,8 @@
   // ┌────────────────────────────┐
   // │ Checkboxes & Radio Buttons │
   // └────────────────────────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#checkboxes
-  //  ↳ http://esri.github.io/calcite-web/components/#radio-buttons
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#checkboxes
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#radio-buttons
   //  ↳ components → _checkboxes.md
   //  ↳ components → _radio-buttons.md
   input[type='radio'], input[type='checkbox'] {
@@ -246,7 +246,7 @@
   // ┌─────────┐
   // │ Selects │
   // └─────────┘
-  //  ↳ http://esri.github.io/calcite-web/components/#selects
+  //  ↳ http://esri.github.io/calcite-web/documentation/components/#selects
   //  ↳ components → _selects.md
   select {
     background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNi4wLjQsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iMTAwcHgiIGhlaWdodD0iMTAwcHgiIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxnPg0KCTxwYXRoIGZpbGw9IiM1OTU5NTkiIGQ9Ik03NS43NDksMzcuNDY2YzAuNDI1LDAuNDI1LDAuNTUyLDEuMDYzLDAuMzIyLDEuNjE4Qzc1Ljg0MSwzOS42MzksNzUuMzAxLDQwLDc0LjY5OSw0MGgtNDkuNA0KCQljLTAuNiwwLTEuMTQzLTAuMzYyLTEuMzcyLTAuOTE3Yy0wLjIzLTAuNTU1LTAuMTAzLTEuMTkzLDAuMzIyLTEuNjE4bDIzLjQ0LTIzLjQ0YzEuMjc2LTEuMjc2LDMuMzQzLTEuMjc2LDQuNjIsMEw3NS43NDksMzcuNDY2DQoJCUw3NS43NDksMzcuNDY2eiBNMjQuMjUsNjIuNTM0Yy0wLjQyNi0wLjQyNS0wLjU1My0xLjA2My0wLjMyMy0xLjYxOGMwLjIzLTAuNTU1LDAuNzctMC45MTYsMS4zNy0wLjkxNkg3NC43DQoJCWMwLjYwMiwwLDEuMTQzLDAuMzU5LDEuMzczLDAuOTE2YzAuMjMsMC41NTUsMC4xMDMsMS4xOTMtMC4zMjIsMS42MThMNTIuMzEsODUuOTc3Yy0xLjI3NSwxLjI3NS0zLjM0NCwxLjI3NC00LjYyLDBMMjQuMjUsNjIuNTM0eg0KCQkiLz4NCjwvZz4NCjwvc3ZnPg0K');

--- a/lib/sass/calcite-web/components/_label.scss
+++ b/lib/sass/calcite-web/components/_label.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Label  │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#label
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#label
 //  ↳ components → _label.md
 
 @mixin label() {

--- a/lib/sass/calcite-web/components/_loader.scss
+++ b/lib/sass/calcite-web/components/_loader.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Loader │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#loader
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#loader
 //  ↳ components → _loader.md
 
 $loader-width: 0.85rem;

--- a/lib/sass/calcite-web/components/_panel.scss
+++ b/lib/sass/calcite-web/components/_panel.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Panels │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#panels
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#panels
 //  ↳ components → _panels.md
 
 @mixin panel() {

--- a/lib/sass/calcite-web/components/_table.scss
+++ b/lib/sass/calcite-web/components/_table.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Tables │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#tables
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#tables
 //  ↳ components → _tables.md
 @mixin table() {
   width: 100%;

--- a/lib/sass/calcite-web/components/_tooltip.scss
+++ b/lib/sass/calcite-web/components/_tooltip.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Tooltips │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/components/#tooltips
+//  ↳ http://esri.github.io/calcite-web/documentation/components/#tooltips
 //  ↳ components → _tooltips.md
 @if $include-tooltip {
   $multiline-max-width: 250px;

--- a/lib/sass/calcite-web/grid/_block-groups.scss
+++ b/lib/sass/calcite-web/grid/_block-groups.scss
@@ -1,7 +1,7 @@
 // ┌──────────────┐
 // │ Block Groups │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#block-groups
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#block-groups
 //  ↳ grid → _block-groups.md
 
 $half-gutter: 0.75 * $column-gutter;
@@ -81,7 +81,7 @@ $full-gutter: $half-gutter * 2;
 // ┌─────────────────────────┐
 // │ Responsive Block Groups │
 // └─────────────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#responsive-block-groups
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#responsive-block-groups
 //  ↳ grid → _responsive-block-groups.md
 @if $block-grid == true {
   @include respond-to($medium) {

--- a/lib/sass/calcite-web/grid/_columns.scss
+++ b/lib/sass/calcite-web/grid/_columns.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Container │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#container
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#container
 //  ↳ grid → _container.md
 
 @mixin grid-container() {
@@ -18,7 +18,7 @@
 // ┌─────────┐
 // │ Columns │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#columns
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#columns
 //  ↳ grid → _columns.md
 
 %column {
@@ -55,7 +55,7 @@
 // ┌────────────────┐
 // │ First and Last │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#first-and-last
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#first-and-last
 //  ↳ grid → _first-and-last.md
 
 @mixin first-column() {
@@ -81,7 +81,7 @@
 // ┌────────────────────┐
 // │ Responsive Columns │
 // └────────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#responsive-columns
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#responsive-columns
 //  ↳ grid → _responsive-columns.md
 
 @mixin responsive-column() {

--- a/lib/sass/calcite-web/grid/_grid.scss
+++ b/lib/sass/calcite-web/grid/_grid.scss
@@ -1,7 +1,7 @@
 // ┌──────┐
 // │ Grid │
 // └──────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#overview
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#overview
 //  ↳ grid → _overview.md
 @import "mixins";
 @import "columns";

--- a/lib/sass/calcite-web/grid/_gutter.scss
+++ b/lib/sass/calcite-web/grid/_gutter.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Gutter │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#gutter
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#gutter
 //  ↳ grid → _gutter.md
 
 @mixin gutter-left-quarter() {

--- a/lib/sass/calcite-web/grid/_leader-trailer.scss
+++ b/lib/sass/calcite-web/grid/_leader-trailer.scss
@@ -1,7 +1,7 @@
 // ┌────────────────┐
 // │ Leader Trailer │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#leader-and-trailer
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#leader-and-trailer
 //  ↳ grid → _leader-and-trailer.md
 
 @mixin leader-half()  { margin-top:    0.5 * $baseline; }

--- a/lib/sass/calcite-web/grid/_left-right.scss
+++ b/lib/sass/calcite-web/grid/_left-right.scss
@@ -1,7 +1,7 @@
 // ┌────────────────┐
 // │ Left and Right │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#left-and-right
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#left-and-right
 //  ↳ grid → _left-and-right.md
 
 @mixin include-left-right(){

--- a/lib/sass/calcite-web/grid/_pre-post.scss
+++ b/lib/sass/calcite-web/grid/_pre-post.scss
@@ -1,7 +1,7 @@
 // ┌──────────────┐
 // │ Pre and Post │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#pre-and-post
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#pre-and-post
 //  ↳ grid → _pre-and-post.md
 
 @mixin responsive-pre-post(){

--- a/lib/sass/calcite-web/grid/_show-hide.scss
+++ b/lib/sass/calcite-web/grid/_show-hide.scss
@@ -1,7 +1,7 @@
 // ┌───────────────┐
 // │ Show and Hide │
 // └───────────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#show-and-hide
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#show-and-hide
 //  ↳ grid → _show-and-hide.md
 
 // Responsive Show and Hide

--- a/lib/sass/calcite-web/icons/_icon-colors.scss
+++ b/lib/sass/calcite-web/icons/_icon-colors.scss
@@ -1,7 +1,7 @@
 // ┌──────────────────┐
 // │ Icon Font Colors │
 // └──────────────────┘
-//  ↳ http://esri.github.io/calcite-web/icons/#icon-font-colors
+//  ↳ http://esri.github.io/calcite-web/documenation/icons/#icon-font-colors
 //  ↳ icons → _icon-font.md
 
 @if $include-icon-font == true {

--- a/lib/sass/calcite-web/patterns/_accordion.scss
+++ b/lib/sass/calcite-web/patterns/_accordion.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Accordion │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#accordion
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#accordion
 //  ↳ patterns → _accordion.md
 
 @mixin accordion() {

--- a/lib/sass/calcite-web/patterns/_drawers.scss
+++ b/lib/sass/calcite-web/patterns/_drawers.scss
@@ -1,7 +1,7 @@
 // ┌─────────┐
 // │ Drawers │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#drawers
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#drawers
 //  ↳ patterns → _drawers.md
 
 $transform-transition: transform 200ms cubic-bezier(0.215, 0.440, 0.420, 0.880);

--- a/lib/sass/calcite-web/patterns/_filter-dropdown.scss
+++ b/lib/sass/calcite-web/patterns/_filter-dropdown.scss
@@ -1,7 +1,7 @@
 // ┌─────────────────┐
 // │ Filter Dropdown │
 // └─────────────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#filter-dropdown
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#filter-dropdown
 //  ↳ patterns → _filter-dropdown.md
 
 @mixin filter-dropdown-input() {

--- a/lib/sass/calcite-web/patterns/_footer.scss
+++ b/lib/sass/calcite-web/patterns/_footer.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Footer │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#footer
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#footer
 //  ↳ patterns → _footer.md
 @if $include-sticky-footer == true {
   body {

--- a/lib/sass/calcite-web/patterns/_modal.scss
+++ b/lib/sass/calcite-web/patterns/_modal.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Modals │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#modals
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#modals
 //  ↳ patterns → _modals.md
 
 @mixin modal-overlay() {

--- a/lib/sass/calcite-web/patterns/_search.scss
+++ b/lib/sass/calcite-web/patterns/_search.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Search │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#search
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#search
 //  ↳ patterns → _search.md
 
 @mixin search-overlay() {

--- a/lib/sass/calcite-web/patterns/_side-nav.scss
+++ b/lib/sass/calcite-web/patterns/_side-nav.scss
@@ -1,7 +1,7 @@
 // ┌─────────┐
 // │ Sidenav │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#side-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#side-nav
 //  ↳ patterns → _side-nav.md
 
 @mixin side-nav() {

--- a/lib/sass/calcite-web/patterns/_sub-nav.scss
+++ b/lib/sass/calcite-web/patterns/_sub-nav.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Subnav │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#sub-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#sub-nav
 //  ↳ patterns → _sub-nav.md
 $subnav-link-underline: linear-gradient(to top, transparent 94%, $white 96%, $white 100%);
 

--- a/lib/sass/calcite-web/patterns/_tabs.scss
+++ b/lib/sass/calcite-web/patterns/_tabs.scss
@@ -1,7 +1,7 @@
 // ┌──────┐
 // │ Tabs │
 // └──────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#tabs
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#tabs
 //  ↳ patterns → _tabs.md
 
 @mixin tab-nav(){

--- a/lib/sass/calcite-web/patterns/_third-nav.scss
+++ b/lib/sass/calcite-web/patterns/_third-nav.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Thirdnav │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#third-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#third-nav
 //  ↳ patterns → _third-nav.md
 
 @mixin third-nav() {

--- a/lib/sass/calcite-web/patterns/_top-nav.scss
+++ b/lib/sass/calcite-web/patterns/_top-nav.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Topnav │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#top-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#top-nav
 //  ↳ patterns → _top-nav.md
 @mixin top-nav {
   position: relative;

--- a/lib/sass/calcite-web/patterns/_user-nav.scss
+++ b/lib/sass/calcite-web/patterns/_user-nav.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Modals │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/patterns/#user-nav
+//  ↳ http://esri.github.io/calcite-web/documentation/patterns/#user-nav
 //  ↳ patterns → _user-nav.md
 
 @mixin user-name () {

--- a/lib/sass/calcite-web/type/_faces.scss
+++ b/lib/sass/calcite-web/type/_faces.scss
@@ -1,7 +1,7 @@
 // ┌─────────────┐
 // │ Header Face │
 // └─────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#avenir-regular
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#avenir-regular
 //  ↳ type → _avenir-regular.md
 
 @mixin avenir-light() {
@@ -48,7 +48,7 @@
 // ┌───────────┐
 // │ Code Face │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#code-face
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#code-face
 //  ↳ type → _code-face.md
 
 @mixin code-face() {

--- a/lib/sass/calcite-web/type/_mixins.scss
+++ b/lib/sass/calcite-web/type/_mixins.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Tracking │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#tracking
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#tracking
 //  ↳ sass → _tracking.md
 
 @mixin tracking($n) {
@@ -11,7 +11,7 @@
 // ┌─────────┐
 // │ Leading │
 // └─────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#leading
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#leading
 //  ↳ sass → _leading.md
 
 @mixin leading($n) {
@@ -21,7 +21,7 @@
 // ┌──────────────┐
 // │ Word Spacing │
 // └──────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#word-spacing
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#word-spacing
 //  ↳ sass → _word-spacing.md
 
 @mixin word-spacing($n) {
@@ -31,7 +31,7 @@
 // ┌────────────────┐
 // │ Text Modifiers │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#text-modifiers
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#text-modifiers
 //  ↳ type → _text-modifiers.md
 
 @mixin text-inline() {
@@ -88,7 +88,7 @@
 // ┌────────────┐
 // │ List Plain │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#list-plain
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#list-plain
 //  ↳ type → _list-plain.md
 
 @mixin list-plain() {
@@ -102,7 +102,7 @@
 // ┌───────────────┐
 // │ List Numbered │
 // └───────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#list-numbered
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#list-numbered
 //  ↳ type → _list-numbered.md
 
 @mixin list-numbered() {
@@ -171,7 +171,7 @@
 // ┌────────────┐
 // │ Text Color │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#text-color
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#text-color
 //  ↳ type → _text-color.md
 
 @mixin text-color($value) {
@@ -181,7 +181,7 @@
 // ┌────────────┐
 // │ Link Color │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/type/#link-color
+//  ↳ http://esri.github.io/calcite-web/documenation/type/#link-color
 //  ↳ type → _link-color.md
 
 @mixin link-color($value, $light-value) {

--- a/lib/sass/calcite-web/type/_scale.scss
+++ b/lib/sass/calcite-web/type/_scale.scss
@@ -1,7 +1,7 @@
 // ┌───────────────┐
 // │ Modular Scale │
 // └───────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#modular-scale
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#modular-scale
 //  ↳ sass → _modular-scale.md
 @function modular-scale($increment) {
   $v1: $body-size;
@@ -112,7 +112,7 @@
 // ┌───────────┐
 // │ Font Size │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#font-size
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#font-size
 //  ↳ sass → _font-size.md
 
 @mixin font-size($n) {

--- a/lib/sass/calcite-web/utils/_animation.scss
+++ b/lib/sass/calcite-web/utils/_animation.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Animation │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#animation
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#animation
 //  ↳ components → _utility-mixins.md
 
 @mixin animation ($animations...) {

--- a/lib/sass/calcite-web/utils/_appearance.scss
+++ b/lib/sass/calcite-web/utils/_appearance.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Appearance │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#appearance
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#appearance
 //  ↳ components → _utility-mixins.md
 
 @mixin appearance ($value) {

--- a/lib/sass/calcite-web/utils/_box-shadow.scss
+++ b/lib/sass/calcite-web/utils/_box-shadow.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Box Shadow │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#box-shadow
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#box-shadow
 //  ↳ components → _utility-mixins.md
 
 @mixin box-shadow ($shadow) {

--- a/lib/sass/calcite-web/utils/_box-sizing.scss
+++ b/lib/sass/calcite-web/utils/_box-sizing.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Box Sizing │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#box-sizing
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#box-sizing
 //  ↳ components → _utility-mixins.md
 
 @mixin box-sizing ($box) {

--- a/lib/sass/calcite-web/utils/_calc.scss
+++ b/lib/sass/calcite-web/utils/_calc.scss
@@ -1,7 +1,7 @@
 // ┌──────┐
 // │ Calc │
 // └──────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#calc
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#calc
 //  ↳ components → _utility-mixins.md
 
 @mixin calc($property, $value) {

--- a/lib/sass/calcite-web/utils/_clearfix.scss
+++ b/lib/sass/calcite-web/utils/_clearfix.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Clearfix │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#clearfix
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#clearfix
 //  ↳ components → _utility-mixins.md
 
 @mixin clearfix() {

--- a/lib/sass/calcite-web/utils/_inline.scss
+++ b/lib/sass/calcite-web/utils/_inline.scss
@@ -1,7 +1,7 @@
 // ┌────────┐
 // │ Inline │
 // └────────┘
-//  ↳ http://esri.github.io/calcite-web/grid/#inline-block
+//  ↳ http://esri.github.io/calcite-web/documentation/grid/#inline-block
 //  ↳ grid → _inline-block.md
 
 @mixin inline-block() {

--- a/lib/sass/calcite-web/utils/_keyframes.scss
+++ b/lib/sass/calcite-web/utils/_keyframes.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Keyframes │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#keyframes
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#keyframes
 //  ↳ components → _utility-mixins.md
 
 @mixin keyframes ($name) {

--- a/lib/sass/calcite-web/utils/_prefixer.scss
+++ b/lib/sass/calcite-web/utils/_prefixer.scss
@@ -1,7 +1,7 @@
 // ┌──────────┐
 // │ Prefixer │
 // └──────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#prefixer
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#prefixer
 //  ↳ components → _utility-mixins.md
 
 $prefix-for-webkit:    true !default;

--- a/lib/sass/calcite-web/utils/_responsive.scss
+++ b/lib/sass/calcite-web/utils/_responsive.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Respond-To │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#respond-to
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#respond-to
 //  ↳ components → _utility-mixins.md
 
 @mixin respond-to($max: null, $min: null, $type: screen) {

--- a/lib/sass/calcite-web/utils/_transform.scss
+++ b/lib/sass/calcite-web/utils/_transform.scss
@@ -1,7 +1,7 @@
 // ┌───────────┐
 // │ Transform │
 // └───────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#transform
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#transform
 //  ↳ components → _utility-mixins.md
 
 @mixin transform($property: none) {

--- a/lib/sass/calcite-web/utils/_transition.scss
+++ b/lib/sass/calcite-web/utils/_transition.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Transition │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#transition
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#transition
 //  ↳ components → _utility-mixins.md
 
 $transition-prefixes: webkit spec;

--- a/lib/sass/calcite-web/utils/_utils.scss
+++ b/lib/sass/calcite-web/utils/_utils.scss
@@ -1,7 +1,7 @@
 // ┌────────────────┐
 // │ Utility Mixins │
 // └────────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#utility-mixins
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#utility-mixins
 //  ↳ components → _utility-mixins.md
 @import "animation";
 @import "appearance";

--- a/lib/sass/calcite-web/utils/_visibility.scss
+++ b/lib/sass/calcite-web/utils/_visibility.scss
@@ -1,7 +1,7 @@
 // ┌────────────┐
 // │ Visibility │
 // └────────────┘
-//  ↳ http://esri.github.io/calcite-web/sass/#visibility
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#visibility
 //  ↳ sass → _utility-mixins.md
 
 // Hide


### PR DESCRIPTION
This commit changes all documentation links with the pattern `http://esri.github.io/calcite-web/section-name` to `http://esri.github.io/calcite-web/documentation/section-name`.