### PR TITLE
second attempt at supplementing aria roles external doc

### DIFF
--- a/docs/source/presentations/calcite-web-deep-dive.html
+++ b/docs/source/presentations/calcite-web-deep-dive.html
@@ -667,6 +667,7 @@ layout: layouts/_presentation:content
   <div class="slide-content">
     <h4 class="font-size-4">List of Roles:</h4>
     <a class="font-size-2" href="https://www.w3.org/TR/2009/WD-wai-aria-20090224/#roles">w3.org/TR/2009/WD-wai-aria-20090224/#roles</a>
+    <a class="font-size-2" href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques">developer.mozilla.org/en-US/docs/Web/Accessibility/...</a>
   </div>
 </div>
 


### PR DESCRIPTION
`<a>` tags are infinitely more clickable when they include real text.

(and now i understand that your `gh-pages` source is actually maintained in `master`)

![reading rainbow](https://alcoholicsconspicuous.files.wordpress.com/2011/07/reading-rainbow.gif)