### PR TITLE
Bump Parallelshell Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ncp": "^2.0.0",
     "node-sass": "^4.5.3",
     "npm-run-series": "^1.0.0",
-    "parallelshell": "^2.0.0",
+    "parallelshell": "^3.0.0",
     "request": "^2.73.0",
     "rerun-script": "^0.6.0",
     "rollup": "^0.41.4",


### PR DESCRIPTION
Update from 2.0 -> 3.0, resolves issue as found on GitHub:
https://github.com/darkguy2008/parallelshell/issues/57

Adds support for Node  >= 8