### PR TITLE
Update button border hover styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+### Fixes
+- make button border colors match background on hover (#840)
+
 ## 1.0.0-rc.8
 
 ### Fixes

--- a/lib/sass/calcite-web/components/_button.scss
+++ b/lib/sass/calcite-web/components/_button.scss
@@ -20,8 +20,9 @@
   @include font-size(-1);
   &:hover {
     text-decoration: none;
-    background-color: $dark-blue;
     color: $white;
+    background-color: $dark-blue;
+    border-color: $dark-blue;
   }
 }
 
@@ -60,6 +61,7 @@
       &:hover {
         color: $white;
         background: $dark-gray;
+        border-color: $dark-gray;
       }
     }
 
@@ -70,6 +72,7 @@
       &:hover {
         color: $gray;
         background: $white;
+        border-color: $white;
       }
     }
 
@@ -80,6 +83,7 @@
     &:hover {
       color: $off-black;
       background: $lightest-gray;
+      border-color: $lightest-gray;
     }
   }
 
@@ -138,6 +142,7 @@
     border-color: $value;
     &:hover {
       background-color: $hover-value;
+      border-color: $hover-value;
     }
   }
 


### PR DESCRIPTION
Ensure border and background colors match on hover. For clear-white, show same color border on hover to maintain correct width.

Update to requested style, making sure other button colors and styles match the paradigm: https://github.com/Esri/calcite-web/issues/840