### PR TITLE
Quick Reference Improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ Adding a component to Calcite Web requires a few steps:
 ```
         - title: 'Tooltips' # Human readable headline
           link: tooltips    # Name used for .md and .html files
+          status: ['complete','inprogress','proposed','unplanned',false] # this will set the component status, false will hide from status table
+          hidden: [true] # set 'hidden: true' to hide components from appearing in documentation. Useful for showing in progress components on the status table
           modifiers:        # List of modifier classes
             - tooltip-left  # If you don't need modifier classes
             - tooltip-right # just use `modifiers: true`

--- a/docs/source/assets/css/quick-reference.scss
+++ b/docs/source/assets/css/quick-reference.scss
@@ -14,11 +14,12 @@
   user-select: all;
 }
 
-.class-name { white-space: nowrap; }
+.class-name {
+  white-space: nowrap;
+}
 
 .class-name-wrapper {
   @include margin-gutter-right-quarter();
-
   display: inline-block;
 }
 
@@ -34,19 +35,45 @@
 
   .class-name-wrapper {
     //@include trailer-quarter();
-
     white-space: nowrap;
     line-height: 1;
   }
 
   .class-name {
     display: inline;
-
     white-space: normal;
   }
+
 }
 
 .icon-wrap {
   position: absolute;
   left: 0;
+}
+
+.changelog-styled {
+  padding: 10px;
+
+  h2:not(:first-of-type) {
+    color: $darker-gray;
+  }
+
+  h2:nth-of-type(2) {
+    border-top: 1px solid $lighter-gray;
+    margin-top: $baseline * 2;
+    padding-top: $baseline * 2;
+  }
+
+  h2:not(:first-of-type) ~ * {
+    color: $darker-gray;
+    font-style: italic;
+  }
+
+}
+
+.quick-reference-link {
+  height: 16px;
+  width: auto;
+  margin-left: $baseline * 0.25;
+  vertical-align: middle;
 }

--- a/docs/source/layouts/_doc.html
+++ b/docs/source/layouts/_doc.html
@@ -15,150 +15,151 @@
             <a class="sub-nav-link {% if url == slug %}is-active{% endif %}" href="{{relativePath}}{{slug}}">{{ sec.title }}</a>
           {% endfor %}
         </nav>
-
         <select class="tablet-show select-full trailer-half js-select-nav">
           {% for title, sec in data.table_of_contents %}
-          {% set slug = '/documentation/' + sec.base + '/' %}
-          {% if sec.base == 'get-started' %}
-            {% set slug = '/documentation/' %}
-          {% endif %}
+            {% set slug = '/documentation/' + sec.base + '/' %}
+            {% if sec.base == 'get-started' %}
+              {% set slug = '/documentation/' %}
+            {% endif %}
             <option value="{{relativePath}}{{slug}}" {% if url == slug %}selected{% endif %}>{{ sec.title }}</option>
           {% endfor %}
         </select>
-
       </div>
     </div>
   </header>
 {% endblock %}
 
 {% block content %}
-<div class="grid-container leader-1">
-  <div class="column-6 tablet-column-12">
-    <aside class="side-nav tablet-hide" aria-role="complementary">
-      {% for group in data.table_of_contents[section].navigation %}
-        <h4 class="side-nav-title">{{ group.group }}</h4>
-        <!-- <nav aria-role="navigation" aria-labelledby="sidenav"> -->
-        <nav aria-role="navigation">
-          {% for page in group.pages %}
-            {% if page.title == 'Overview' %}
-              <a href="#{{group.group | replace(" ", "-") | lower}}" class="side-nav-link">{{page.title}}</a>
-            {% else %}
-              <a href="#{{page.link}}" class="side-nav-link">{{page.title}}</a>
-            {% endif %}
-          {% endfor %}
-        </nav>
-      {% endfor %}
-    </aside>
-    <label class="tablet-show">
-      Jump to section:
-      <select class="select-full js-select-nav">
+  <div class="grid-container leader-1">
+    <div class="column-6 tablet-column-12">
+      <aside class="side-nav tablet-hide" aria-role="complementary">
         {% for group in data.table_of_contents[section].navigation %}
-        <optgroup label="{{ group.group }}">
-          {% for page in group.pages %}
-            {% if page.title == 'Overview' %}
-              <option value="#{{group.group | replace(" ", "-") | lower}}">{{page.title}}</option>
-            {% else %}
-              <option value="#{{page.link}}">{{page.title}}</option>
+          {% if group.hidden != true %}
+            <h4 class="side-nav-title">{{ group.group }}</h4>
+            <!-- <nav aria-role="navigation" aria-labelledby="sidenav"> -->
+            <nav aria-role="navigation">
+              {% for page in group.pages %}
+                {% if page.title == 'Overview' %}
+                  <a href="#{{group.group | replace(" ", "-") | lower}}" class="side-nav-link">{{page.title}}</a>
+                {% else %}
+                  <a href="#{{page.link}}" class="side-nav-link">{{page.title}}</a>
+                {% endif %}
+              {% endfor %}
+            </nav>
+          {% endif %}
+        {% endfor %}
+      </aside>
+      <label class="tablet-show">
+        Jump to section:
+        <select class="select-full js-select-nav">
+          {% for group in data.table_of_contents[section].navigation %}
+            {% if group.hidden != true %}
+              <optgroup label="{{ group.group }}">
+                {% for page in group.pages %}
+                  {% if page.title == 'Overview' %}
+                    <option value="#{{group.group | replace(" ", "-") | lower}}">{{page.title}}</option>
+                  {% else %}
+                    <option value="#{{page.link}}">{{page.title}}</option>
+                  {% endif %}
+                {% endfor %}
+              </optgroup>
             {% endif %}
           {% endfor %}
-        </optgroup>
-        {% endfor %}
-      </select>
-    </label>
-    <div class="js-sticky scroll-show tablet-hide" data-top="46">
-      <a href="#" class="btn btn-clear">Back to Top</a>
+        </select>
+      </label>
+      <div class="js-sticky scroll-show tablet-hide" data-top="46">
+        <a href="#" class="btn btn-clear">Back to Top</a>
+      </div>
     </div>
-  </div>
 
-  <a id="skip-to-content" tabindex="0"></a>
-  <main class="column-17 phone-column-6 tablet-column-12 pre-1 rtl-post-0 tablet-leader-1" role="main">
+    <a id="skip-to-content" tabindex="0"></a>
+    <main class="column-17 phone-column-6 tablet-column-12 pre-1 rtl-post-0 tablet-leader-1" role="main">
+      {% for group in data.table_of_contents[section].navigation %}
 
-    {% for group in data.table_of_contents[section].navigation %}
-      <h1 class="text-rule" id="{{group.group | replace(" ", "-") | lower}}" tabindex="0">{{group.group}}</h1>
-      {% for page in group.pages %}
-        <section>
-          {% if page.title != 'Overview' %}
-            <h2 id="{{page.link}}" tabindex="0">{{page.title}}</h2>
-          {% endif %}
+        {% if group.hidden != true %}
+          <h1 class="text-rule" id="{{group.group | replace(" ", "-") | lower}}" tabindex="0">{{group.group}}</h1>
+        {% endif %}
 
-          {% markdown %}{% include 'documentation/' + data.table_of_contents[section].base + '/_' + page.link %}{% endmarkdown %}
+        {% for page in group.pages %}
 
-          {% if page.title == 'Social Icons' %}
-            <div class="block-group block-group-3-up">
-              {% for icon in data.icons %}
+          {% if page.hidden != true %}
+            <section>
+              {% if page.title != 'Overview' %}
+                <h2 id="{{page.link}}" tabindex="0">{{page.title}}</h2>
+              {% endif %}
+            {% markdown %}{% include 'documentation/' + data.table_of_contents[section].base + '/_' + page.link %}{% endmarkdown %}
+            {% if page.title == 'Social Icons' %}
+              <div class="block-group block-group-3-up">
+                {% for icon in data.icons %}
+                  <div class="block">
+                    <a href="" class="icon-social-{{icon}}" aria-label="{{icon}}"></a>
+                    <p class="trailer-1 leader-half"><code>.icon-social-{{icon}}</code></p>
+                  </div>
+                {% endfor %}
+              </div>
+            {% endif %}
+            {% if page.title == 'User Interface Icons' %}
+              {% include 'layouts/_inline-icons' %}
+            {% endif %}
+            {% if page.title == 'Icon Font Colors' %}
+              <div class="block-group block-group-3-up">
                 <div class="block">
-                  <a href="" class="icon-social-{{icon}}" aria-label="{{icon}}"></a>
-                  <p class="trailer-1 leader-half"><code>.icon-social-{{icon}}</code></p>
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-green" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-green</code></p>
                 </div>
-              {% endfor %}
-            </div>
-          {% endif %}
-
-          {% if page.title == 'User Interface Icons' %}
-            {% include 'layouts/_inline-icons' %}
-          {% endif %}
-
-          {% if page.title == 'Icon Font Colors' %}
-            <div class="block-group block-group-3-up">
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-green" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-green</code></p>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-light-blue" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-light-blue</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-blue" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-blue</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-dark-blue" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-dark-blue</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-purple" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-purple</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-orange" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-orange</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-gray" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-gray</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-red" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-red</code></p>
+                </div>
+                <div class="block">
+                  <span class="font-size-5 icon-ui-check-mark icon-ui-yellow" aria-label="check-mark "></span>
+                  <p class="trailer-1 leader-half"><code>icon-ui-yellow</code></p>
+                </div>
               </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-light-blue" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-light-blue</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-blue" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-blue</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-dark-blue" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-dark-blue</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-purple" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-purple</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-orange" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-orange</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-gray" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-gray</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-red" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-red</code></p>
-              </div>
-              <div class="block">
-                <span class="font-size-5 icon-ui-check-mark icon-ui-yellow" aria-label="check-mark "></span>
-                <p class="trailer-1 leader-half"><code>icon-ui-yellow</code></p>
-              </div>
-            </div>
-          {% endif %}
-
-          {% if page.modifiers %}
-            <h3 class="leader-2" tabindex="0">Modifiers</h3>
-            <div class="styleguide-modifiers">
-              <div class="styleguide-modifier-example">
-                {% include 'documentation/' + data.table_of_contents[section].base + '/sample-code/_' + page.link %}
-              </div>
-              {% for modifier in page.modifiers %}
+            {% endif %}
+            {% if page.modifiers %}
+              <h3 class="leader-2" tabindex="0">Modifiers</h3>
+              <div class="styleguide-modifiers">
                 <div class="styleguide-modifier-example">
                   {% include 'documentation/' + data.table_of_contents[section].base + '/sample-code/_' + page.link %}
-                  <code class="modifier-name">.{{ modifier }}</code>
                 </div>
-              {% endfor %}
-            </div>
+                {% for modifier in page.modifiers %}
+                  <div class="styleguide-modifier-example">
+                    {% include 'documentation/' + data.table_of_contents[section].base + '/sample-code/_' + page.link %}
+                    <code class="modifier-name">.{{ modifier }}</code>
+                  </div>
+                {% endfor %}
+              </div>
 {% markdown %}
 ```
 {% set modifier = "modifier-class" %}{% include 'documentation/' + data.table_of_contents[section].base + '/sample-code/_' + page.link %}
 ```
 {% endmarkdown %}
           {% endif %}
-
           {% if page.colors %}
             <div class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up">
               {% for color in page.colors %}
@@ -169,11 +170,9 @@
                     <p class="trailer-0 font-size--2"><code>{{data.colors["$" + color]}}</code></p>
                   </div>
                 </div>
-
               {% endfor %}
             </div>
           {% endif %}
-
           {% if page.variables %}
             <div class="block-group block-group-5-up">
               {% for variable in page.variables %}
@@ -184,11 +183,10 @@
               {% endfor %}
             </div>
           {% endif %}
-
         </section>
-        <hr>
-      {% endfor %}
+      {% endif %}
     {% endfor %}
-  </main>
+  {% endfor %}
+</main>
 </div>
 {% endblock %}

--- a/docs/source/layouts/_doc.html
+++ b/docs/source/layouts/_doc.html
@@ -4,8 +4,8 @@
   <header class="sub-nav" role="banner">
     <div class="grid-container">
       <div class="column-24">
-        <h1 class="sub-nav-title leader-1 text-white">Documentation</h1>
-        <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide">Download Latest Release</a>
+   <h1 class="sub-nav-title text-white leader-1">Documentation</h1>
+      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
         <nav class="sub-nav-list tablet-hide" role="navigation" aria-labelledby="subnav">
           {% for title, sec in data.table_of_contents %}
             {% set slug = '/documentation/' + sec.base + '/' %}

--- a/docs/source/layouts/_examples.html
+++ b/docs/source/layouts/_examples.html
@@ -4,8 +4,8 @@
   <header class="sub-nav" role="banner">
     <div class="grid-container">
       <div class="column-24">
-        <h1 class="sub-nav-title leader-1 text-white">Examples</h1>
-        <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1">Download Latest Release</a>
+        <h1 class="sub-nav-title text-white leader-1">Guides</h1>
+        <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
         <nav class="sub-nav-list" role="navigation" aria-labelledby="subnav">
           <a class="sub-nav-link {% if active == 'overview' %}is-active{% endif %}" href="{{relativePath}}/examples">Overview</a>
           <a href="{{relativePath}}/examples/core" class="sub-nav-link {% if active == 'core' %} is-active {% endif %}">Basic Pages</a>

--- a/docs/source/layouts/_guide.html
+++ b/docs/source/layouts/_guide.html
@@ -4,15 +4,13 @@
 <header class="sub-nav" role="banner">
   <div class="grid-container">
     <div class="column-24">
-      <h1 class="sub-nav-title text-white leader-1 trailer-1">Guides</h1>
+      <h1 class="sub-nav-title text-white leader-1">Guides</h1>
+      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
       <nav class="sub-nav-list">
         <a class="sub-nav-link {% if url == '/guides/' %}is-active{% endif %}" href="{{relativePath}}/guides/">Overview</a>
         <a class="sub-nav-link {% if url == '/guides/quickstart/' %}is-active{% endif %}" href="{{relativePath}}/guides/quickstart/">Quickstart</a>
-
         <a class="sub-nav-link {% if isDesign %}is-active{% endif %}" href="{{relativePath}}/guides/best-practices/">Best Practices</a>
-
         <a class="sub-nav-link {% if isCode %}is-active{% endif %}" href="{{relativePath}}/guides/code/">Code Styleguides</a>
-
         <a class="sub-nav-link {% if url == '/guides/migration-guide/' %}is-active{% endif %}" href="{{relativePath}}/guides/migration-guide/">Migration Guide</a>
       </nav>
     </div>

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -195,7 +195,7 @@
           </nav>
 
           <div class="column-24 leader-1">
-            <p><small>Copyright © 2015 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+            <p><small>Copyright © 2018 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
           </div>
         </div>
 

--- a/docs/source/layouts/_quick-reference.html
+++ b/docs/source/layouts/_quick-reference.html
@@ -1,84 +1,21 @@
 {% extends "layouts/_layout" %}
 {% set isQuickRef = true %}
-{% block subnav %}
-  <header class="sub-nav" role="banner">
-    <div class="grid-container">
-      <div class="column-24">
-        <h1 class="sub-nav-title leader-1 text-white">Quick Reference</h1>
-        <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide">Download Latest Release</a>
-      </div>
+{% block subnav%}
+
+<header class="sub-nav" role="banner">
+  <div class="grid-container">
+    <div class="column-24">
+      <h1 class="sub-nav-title leader-1 text-white">Quick Reference</h1>
+      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide">Download Latest Release</a>
+      <nav class="sub-nav-list">
+        <a class="sub-nav-link {% if url == '/quick-reference/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/">Component Status</a>
+        <a class="sub-nav-link {% if url == '/quick-reference/class-sheet/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/class-sheet/">Class Sheet</a>
+        <a class="sub-nav-link {% if url == '/quick-reference/changelog/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/changelog/">Changelog</a>
+      </nav>
     </div>
-  </header>
+  </div>
+</header>
 {% endblock %}
-
 {% block content %}
-<div class="grid-container leader-1">
-  <a id="skip-to-content" tabindex="0"></a>
-  <main class="column-24 tablet-leader-1" role="main">
 
-    <input type="search" class="input-minimal input-search font-size-1 trailer-1 leader-1 js-class-filter" placeholder="filter classes by name">
-    <div class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up">
-
-    {% for title, sec in data.table_of_contents %}
-      {% if ( title !== 'get-started' and title !== 'color' and title !== 'patterns' and title !== 'sass' and title !== 'javascript' ) %}
-
-      <section class="quickref-section block">
-        <h4 class="text-rule trailer-1" id="{{sec.title | replace(" ", "-") | lower}}" tabindex="0"><a href="{{relativePath}}/documentation/{{sec.base}}" class="link-darker-gray">{{sec.title}}</a></h4>
-
-        {% for navigation in sec.navigation %}
-          {% for page in navigation.pages %}
-            {% if ( page.classes or (page.modifiers.length > 0) ) and ( page.title !== 'UI Icon Colors' and page.title !== 'Icon Font Colors')%}
-
-            <div class="quick-ref-page js-class">
-              <h5 class="trailer-0 js-category-name " id="{{page.title | replace(" ", "-") | lower}}" tabindex="0"><a href="{{relativePath}}/documentation/{{sec.base}}/#{{ page.link }}" class="link-darker-gray">{{page.title}}</a></h5>
-              <ul class="list-plain font-size--2 trailer-1">
-
-                {% if title !== 'icons' %}
-                  {% for class in page.classes %}
-
-                  <li class="js-class class class-name-wrapper"><code>.<span class="class-name js-class-name">{{ class }}</span></code></li>
-
-                  {% endfor %}
-
-                  {% for modifier in page.modifiers %}
-
-                  <li class="js-class class class-name-wrapper"><code>.<span class="class-name js-class-name">{{ modifier }}</span></code></li>
-
-                  {% endfor %}
-                {% else %}
-                  {% if page.title == 'User Interface Icons' and data.svg %}
-                    {% for icon in data.svg %}
-
-                      <li class="js-class class icon-class">
-                        <span class="font-size--3 left icon-wrap">{% include "assets/img/icons/ui/" + icon.name + ".svg" %}</span>
-                        <code class="icon-name class-name-wrapper">.<span class="class-name js-class-name">icon-ui-{{icon.name}}</span></code>
-                      </li>
-                    {% endfor %}
-                  {% elif page.title == 'Social Icons' and data.icons %}
-                    {% for icon in data.icons %}
-
-                      <li class="js-class class icon-class icon-class-social">
-                        <span class="font-size--8 left icon-wrap icon-social-{{icon}}"></span>
-                        <code class="icon-name class-name-wrapper">.<span class="class-name js-class-name">icon-social-{{icon}}</span></code>
-                      </li>
-
-                    {% endfor %}
-                  {% endif %}
-                {% endif %}
-
-              </ul>
-            </div>
-
-            {% endif %}
-          {% endfor %}
-        {% endfor %}
-
-      </section>
-
-      {% endif %}
-    {% endfor %}
-
-    </div>
-  </main>
-</div>
 {% endblock %}

--- a/docs/source/layouts/_quick-reference.html
+++ b/docs/source/layouts/_quick-reference.html
@@ -5,8 +5,8 @@
 <header class="sub-nav" role="banner">
   <div class="grid-container">
     <div class="column-24">
-      <h1 class="sub-nav-title leader-1 text-white">Quick Reference</h1>
-      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide">Download Latest Release</a>
+      <h1 class="sub-nav-title text-white leader-1">Quick Reference</h1>
+      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
       <nav class="sub-nav-list">
         <a class="sub-nav-link {% if url == '/quick-reference/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/">Component Status</a>
         <a class="sub-nav-link {% if url == '/quick-reference/class-sheet/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/class-sheet/">Class Sheet</a>

--- a/docs/source/quick-reference/changelog/index.html
+++ b/docs/source/quick-reference/changelog/index.html
@@ -1,0 +1,36 @@
+---
+title: Calcite Web
+description: Quickly build beautiful, consistent websites with the Calcite Web Framework
+layout: layouts/_quick-reference
+section: quick-reference
+js:
+- quick-reference
+css:
+- quick-reference
+---
+{% block content %}
+<div class="grid-container leader-1">
+  <main class="column-24 tablet-leader-1" role="main">
+    <div class="column-9 post-1 tablet-column-12">
+      <h2>Changelog</h2>
+      A comprehensive overview of changes and fixes made to Calcite Web. This documentation is auto-generated from our Changelog.
+      <hr>
+
+      You can <a target="blank" href="https://github.com/Esri/calcite-web/blob/master/CHANGELOG.md">view the original CHANGELOG.md on Github</a>
+      <div class="js-sticky scroll-show tablet-hide" data-top="46">
+        <a href="#" class="btn btn-clear">Back to Top</a>
+      </div>
+    </div>
+    <div class="column-14 tablet-first-column tablet-leader-2">
+      <h4 class="trailer-1"><a target="blank" href="https://github.com/Esri/calcite-web/releases" title="Download Latest Release on GitHub">Latest Release
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon quick-reference-link"><path d="M26 30H2V6h14V4H0v28h28V18h-2zM21 8C12.715 8 6 14.717 6 23c0 .336.029.668.051 1h4A11.464 11.464 0 0 1 10 23c0-6.065 4.936-11 11-11h3.004l-6 6h4L30 10l-7.996-8h-4l6 6H21z"/></svg>
+      </a></h4>
+            <div class="panel panel-no-border card card-bar-blue trailer-quarter">
+      <div class="changelog-styled">
+        {% markdown %}{% include '../../CHANGELOG.md' %}{% endmarkdown %}
+      </div>
+    </div>
+    </main>
+  </div>
+  {% endblock %}
+

--- a/docs/source/quick-reference/class-sheet/index.html
+++ b/docs/source/quick-reference/class-sheet/index.html
@@ -1,0 +1,82 @@
+---
+title: Calcite Web
+description: Quickly build beautiful, consistent websites with the Calcite Web Framework
+layout: layouts/_quick-reference
+section: quick-reference
+js:
+  - quick-reference
+css:
+  - quick-reference
+---
+{% block content %}
+  <div class="grid-container leader-1">
+    <a id="skip-to-content" tabindex="0"></a>
+    <main class="column-24 tablet-leader-1">
+
+      <input type="search" class="input-minimal input-search font-size-1 trailer-1 leader-1 js-class-filter" placeholder="filter classes by name">
+      <div class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up">
+
+        {% for title, sec in data.table_of_contents %}
+        {% if ( title !== 'get-started' and title !== 'color' and title !== 'patterns' and title !== 'sass' and title !== 'javascript' ) %}
+
+        <section class="quickref-section block">
+          <h4 class="text-rule trailer-1" id="{{sec.title | replace(" ", "-") | lower}}" tabindex="0"><a href="{{relativePath}}/documentation/{{sec.base}}" class="link-darkest-gray">{{sec.title}}</a></h4>
+
+          {% for navigation in sec.navigation %}
+          {% for page in navigation.pages %}
+          {% if ( page.classes or (page.modifiers.length > 0) ) and ( page.title !== 'UI Icon Colors' and page.title !== 'Icon Font Colors')%}
+
+          <div class="quick-ref-page js-class">
+            <h5 class="trailer-0 js-category-name " id="{{page.title | replace(" ", "-") | lower}}" tabindex="0"><a href="{{relativePath}}/documentation/{{sec.base}}/#{{ page.link }}">{{page.title}}</a></h5>
+            <ul class="list-plain font-size--2 trailer-1">
+
+              {% if title !== 'icons' %}
+              {% for class in page.classes %}
+
+              <li class="js-class class class-name-wrapper"><code>.<span class="class-name js-class-name">{{ class }}</span></code></li>
+
+              {% endfor %}
+
+              {% for modifier in page.modifiers %}
+
+              <li class="js-class class class-name-wrapper"><code>.<span class="class-name js-class-name">{{ modifier }}</span></code></li>
+
+              {% endfor %}
+              {% else %}
+              {% if page.title == 'User Interface Icons' and data.svg %}
+              {% for icon in data.svg %}
+
+              <li class="js-class class icon-class">
+                <span class="font-size--3 left icon-wrap">{% include "assets/img/icons/ui/" + icon.name + ".svg" %}</span>
+                <code class="icon-name class-name-wrapper">.<span class="class-name js-class-name">icon-ui-{{icon.name}}</span></code>
+              </li>
+              {% endfor %}
+              {% elif page.title == 'Social Icons' and data.icons %}
+              {% for icon in data.icons %}
+
+              <li class="js-class class icon-class icon-class-social">
+                <span class="font-size--8 left icon-wrap icon-social-{{icon}}"></span>
+                <code class="icon-name class-name-wrapper">.<span class="class-name js-class-name">icon-social-{{icon}}</span></code>
+              </li>
+
+              {% endfor %}
+              {% endif %}
+              {% endif %}
+
+            </ul>
+          </div>
+
+          {% endif %}
+          {% endfor %}
+          {% endfor %}
+
+        </section>
+
+        {% endif %}
+        {% endfor %}
+
+      </div>
+    </main>
+  </div>
+  {% endblock %}
+

--- a/docs/source/quick-reference/index.html
+++ b/docs/source/quick-reference/index.html
@@ -4,7 +4,112 @@ description: Quickly build beautiful, consistent websites with the Calcite Web F
 layout: layouts/_quick-reference
 section: quick-reference
 js:
-  - quick-reference
+- quick-reference
 css:
-  - quick-reference
+- quick-reference
 ---
+{% block content %}
+<div class="grid-container leader-1">
+  <main class="column-24 tablet-leader-1" role="main">
+    <div class="column-9 post-1 tablet-column-12">
+      <h2>Component Status</h2>
+      This is meant to serve as an "at-a-glance" overview of Calcite Web components. This will be updated with more functionality in the future but for now it should provide a brief overview of the status and availability of components.
+      <h3 class="leader-1 trailer-quarter">Taxonomy</h3>
+      <table class="overflow-auto table-no-table">
+        <thead>
+          <th></th>
+          <th></th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><mark class="label label-green">Complete</mark></td>
+            <td>Complete, documented, and ready to use.</td>
+          </tr>
+          <tr>
+            <td><mark class="label label-yellow">In Progress</mark></td>
+            <td>Actively in development.</td>
+          </tr>
+          <tr>
+            <td><mark class="label label-blue">Proposed</mark></td>
+            <td>Proposed and may be chosen to develop.</td>
+          </tr>
+          <tr>
+            <td><mark class="label">Unplanned</mark></td>
+            <td>An intentional choice was made not to build this.</td>
+          </tr>
+        </tbody>
+      </table>
+      <hr>
+      Want to see a component added to Calcite Web? <a target="blank" href="https://github.com/Esri/calcite-web/issues" title="Submit and issue on Github">Submit an issue on Github</a>.
+    </div>
+    <div class="column-14 tablet-first-column tablet-leader-2">
+      <div class="panel panel-no-border card card-bar-blue trailer-quarter">
+      <table class="overflow-auto table-plain trailer-0">
+        <thead>
+          <tr>
+            <th><h5 class="avenir-bold text-darker-gray trailer-quarter">Component</h5></th>
+            <th><h5 class="avenir-bold text-darker-gray trailer-quarter">Status</h5></th>
+            <th><h5 class="avenir-bold text-darker-gray trailer-quarter">Code</h5></th>
+            <th><h5 class="avenir-bold text-darker-gray trailer-quarter">Docs</h5></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for title, sec in data.table_of_contents %}
+          {% if ( title == 'components' ) %}
+          {% for navigation in sec.navigation %}
+          {% for page in navigation.pages %}
+          {% if page.status != false %}
+          <tr>
+            <td>
+              <h6 class="trailer-0 js-category-name " id="{{page.title | replace(" ", "-") | lower}}" tabindex="0">
+                {% if page.hidden != true %}
+                <a href="{{relativePath}}/documentation/{{sec.base}}/#{{ page.link }}" class="link-off-black" title="View {{page.title}} Component">{{page.title}}</a>
+                {% else %}
+                {{page.title}}
+                {% endif %}
+              </h6>
+            </td>
+            <td>
+              {% if ( page.status == 'complete' ) %}
+              <mark class="label label-green">Complete</mark>
+              {% elseif ( page.status == 'inprogress' ) %}
+              <mark class="label label-yellow">In Progress</mark>
+              {% elseif ( page.status == 'proposed' ) %}
+              <mark class="label label-blue">Proposed</mark>
+              {% elseif ( page.status == 'unplanned' ) %}
+              <mark class="label">Unplanned</mark>
+              {% else %}
+              <mark class="label">Unplanned</mark>
+              {% endif %}
+            </td>
+            <td>
+              {% if page.hidden != true %}
+              <a href="{{relativePath}}/documentation/{{sec.base}}/#{{ page.link }}" class="link-off-black" title="View {{page.title}} Component">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path fill="#5a9359" d="M11.927 22l-6.882-6.883-3 3L11.927 28 31.204 8.728l-3.001-3.001z"/></svg>
+              </a>
+              {% else %}
+              No
+              {% endif %}
+            </td>
+            <td>
+              {% if page.hidden != true %}
+              <a href="{{relativePath}}/documentation/{{sec.base}}/#{{ page.link }}" class="link-off-black" title="View {{page.title}} Component">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon"><path fill="#5a9359" d="M11.927 22l-6.882-6.883-3 3L11.927 28 31.204 8.728l-3.001-3.001z"/></svg>
+              </a>
+              {% else %}
+              No
+              {% endif %}
+            </td>
+          </tr>
+          {% endif %}
+          {% endfor %}
+          {% endfor %}
+          {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/docs/source/search.html
+++ b/docs/source/search.html
@@ -38,34 +38,35 @@ js:
     <hr class="trailer-0 leader-half">
 
     <div class="js-search-list">
-    {% for pageName, page in data.table_of_contents %}
+      {% for pageName, page in data.table_of_contents %}
       {% for group in page.navigation %}
-        {% for section in group.pages %}
-          <section class="js-search-item padding-trailer-1 padding-leader-1 hide" data-rank="0">
-            <h5 class="trailer-half">
-
-              {% set pageUrl = data.table_of_contents[pageName].base + "/" %}
-              {% if pageName == "get-started" %}
-                {% set pageUrl = "" %}
-              {% endif %}
-              <a href="{{relativePath}}/documentation/{{pageUrl}}#{{section.link}}">
-                {% if section.title == "Overview" %}
-                  {{section.title}} ({{page.title}})
-                {% else %}
-                  {{section.title}}
-                {% endif %}
-              </a>
-            </h5>
-            <div class="js-search-item-content hide">
-              {% markdown %}{% include 'documentation/' + data.table_of_contents[pageName].base + '/_' + section.link %}{% endmarkdown %}
-            </div>
-            <!-- populated on the client -->
-            <div class="js-search-item-snippet font-size-0"></div>
-            <a href="{{relativePath}}/documentation/{{data.table_of_contents[pageName].base}}/#{{section.link}}" class="link-gray font-size--2">esri.github.io/calcite-web/documentation/{{data.table_of_contents[pageName].base}}/#{{section.link}}</a>
-          </section>
-        {% endfor %}
+      {% if group.hidden != true %}
+      {% for section in group.pages %}
+      <section class="js-search-item padding-trailer-1 padding-leader-1 hide" data-rank="0">
+        <h5 class="trailer-half">
+          {% set pageUrl = data.table_of_contents[pageName].base + "/" %}
+          {% if pageName == "get-started" %}
+          {% set pageUrl = "" %}
+          {% endif %}
+          <a href="{{relativePath}}/documentation/{{pageUrl}}#{{section.link}}">
+            {% if section.title == "Overview" %}
+            {{section.title}} ({{page.title}})
+            {% else %}
+            {{section.title}}
+            {% endif %}
+          </a>
+        </h5>
+        <div class="js-search-item-content hide">
+          {% markdown %}{% include 'documentation/' + data.table_of_contents[pageName].base + '/_' + section.link %}{% endmarkdown %}
+        </div>
+        <!-- populated on the client -->
+        <div class="js-search-item-snippet font-size-0"></div>
+        <a href="{{relativePath}}/documentation/{{data.table_of_contents[pageName].base}}/#{{section.link}}" class="link-gray font-size--2">esri.github.io/calcite-web/documentation/{{data.table_of_contents[pageName].base}}/#{{section.link}}</a>
+      </section>
       {% endfor %}
-    {% endfor %}
+      {% endif %}
+      {% endfor %}
+      {% endfor %}
     </div>
 
     <section class="js-no-results leader-2 trailer-2 hide">
@@ -74,5 +75,4 @@ js:
     </section>
 
   </div>
-
 </div>

--- a/docs/source/table_of_contents.yml
+++ b/docs/source/table_of_contents.yml
@@ -372,8 +372,10 @@ components:
       pages:
         - title: 'Overview'
           link: overview
+          status: false
         - title: 'Buttons'
           link: buttons
+          status: 'complete'
           classes:
             - btn
           modifiers:
@@ -390,11 +392,13 @@ components:
             - btn-green
         - title: 'Button Groups'
           link: button-groups
+          status: complete
           classes:
             - btn-grouped
           modifiers: true
         - title: 'Labels'
           link: label
+          status: 'complete'
           classes:
             - label
           modifiers:
@@ -404,17 +408,20 @@ components:
             - label-red
         - title: 'Dropdowns'
           link: dropdowns
+          status: 'complete'
           classes:
             - dropdown
           modifiers:
             - dropdown-right
         - title: 'Loader'
           link: loader
+          status: 'complete'
           classes:
             - loader
           modifiers: true
         - title: 'Alerts'
           link: alerts
+          status: 'complete'
           classes:
             - alert
           modifiers:
@@ -424,6 +431,7 @@ components:
             - alert-full
         - title: 'Panels'
           link: panels
+          status: 'complete'
           classes:
             - panel
           modifiers:
@@ -437,6 +445,7 @@ components:
             - panel-dark-blue
         - title: 'Cards'
           link: card
+          status: 'complete'
           classes:
             - card
             - card-shaped
@@ -444,11 +453,13 @@ components:
           modifiers: true
         - title: 'Wide Cards'
           link: card-wide
+          status: 'complete'
           classes:
             - card-wide
           modifiers: true
         - title: 'Breadcrumbs'
           link: breadcrumbs
+          status: 'complete'
           classes:
             - breadcrumbs
             - crumb
@@ -456,6 +467,7 @@ components:
             - breadcrumbs-white
         - title: 'Tooltips'
           link: tooltips
+          status: 'complete'
           classes:
             - tooltip
             - tooltip-multiline
@@ -465,6 +477,7 @@ components:
             - tooltip-top
         - title: 'Tables'
           link: tables
+          status: 'complete'
           classes:
             - overflow-auto
           modifiers:
@@ -475,22 +488,27 @@ components:
             - table-no-table
         - title: 'Skip to Content'
           link: skip
+          status: 'complete'
           classes:
             - skip-to-content
           modifiers: true
         - title: 'Responsive Images'
           link: images
+          status: 'complete'
           modifiers: true
     - group: 'Forms'
       pages:
         - title: 'Overview'
           link: form-overview
+          status: false
           modifiers: true
         - title: 'Form Validation'
           link: form-validation
+          status: 'complete'
           modifiers: true
         - title: 'Text Inputs'
           link: text-inputs
+          status: 'complete'
           modifiers:
             - input-success
             - input-error
@@ -498,6 +516,7 @@ components:
             - input-search input-minimal
         - title: 'Input Groups'
           link: input-groups
+          status: 'complete'
           classes:
             - input-group
             - input-group-input
@@ -505,15 +524,18 @@ components:
           modifiers: true
         - title: 'Selects'
           link: selects
+          status: 'complete'
           modifiers:
             - select-full
         - title: 'Checkboxes'
           link: checkboxes
+          status: 'complete'
           classes:
             - fieldset-checkbox
           modifiers: true
         - title: 'Radio Buttons'
           link: radio-buttons
+          status: 'complete'
           classes:
             - fieldset-radio
           modifiers: true
@@ -521,6 +543,7 @@ components:
       pages:
         - title: 'Overview'
           link: animation
+          status: false
           modifiers:
             - animate-fade-in
             - animate-fade-out
@@ -532,11 +555,24 @@ components:
       pages:
         - title: 'Esri Logo'
           link: esri-logo
+          status: 'complete'
           classes:
             - esri-logo
           modifiers:
             - 'esri-logo-reverse'
             - 'esri-logo-condensed'
+    - group: 'Proposed'
+      hidden: true
+      pages:
+        - title: 'Range Slider'
+          hidden: true
+          status: 'inprogress'
+        - title: 'Toggle Switch'
+          hidden: true
+          status: 'proposed'
+        - title: 'Example'
+          hidden: true
+          status: 'unplanned'
 patterns:
   title: 'Patterns'
   base: patterns


### PR DESCRIPTION
## Add component index and changelog, bump copyright and some clean up

This adds a basic implementation of a component status table. We can work with the terminology and add features later but felt it was important to get a basic version up. Also adds a changelog and a few style clean up items here and there.

### Big Stuff
- Add Component Status to Quick Reference section
    - This is generated from status attributes defined in table_of_contents.yml
- Added two new table_of_contents attributes
    - Status: (this is used to populate the Component Status sheet)
        - ‘complete’
        - ‘inprogress’
        - ‘proposed’
        - ‘unplanned’
        - false
        - —
        - These will populate the component index sheet with status marks, and link to component docs. You can set ‘status: false’ to hide a component from the index sheet (also useful for hiding Overview, etc).
    - Hidden: (this is used to hide groups and components from docs)
        - false
        - —
        - “Hidden” can be set to false on both groups, and components. This will exclude the component from displaying in documentation or example pages. It’s useful for displaying components on the status sheet, but hiding them from documentation.

### Medium Stuff
- Add Changelog to Quick Reference section
    - This is sourced directly from CHANGELOG.md with some styling for current release

### Small Stuff
- Update contribution guidelines to include “status” and “hidden” attributes
- Add “Download Latest Release” button to Guides header
    - This matches the display of all other top-level nav items
    - Make button spacers the same across pages
- Bump copyright from 2015 -> 2018
