### PR TITLE
use 'unreleased' in the changelog instead of the next planned version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0
+## [Unreleased][unreleased]
 
 ### Fixes
 - make button border colors match background on hover (#840)
@@ -1304,3 +1304,6 @@ Begin foundational sass for the framework.
 - KSS Parser
 - CSS Reset
 - Grunt Workflows
+
+[unreleased]: https://github.com/esri/calcite-web/compare/v1.0.0-rc.8...HEAD
+[1.0.0-rc.8]: https://github.com/esri/calcite-web/compare/v1.0.0-rc.7...v1.0.0-rc.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixes
 - make button border colors match background on hover (#840)
 
-## 1.0.0-rc.8
+## [1.0.0-rc.8]
 
 ### Fixes
 - fix rounded buttons in newest chrome


### PR DESCRIPTION
in case you change your mind about what the version number ends up being.

also, right now it looks like you've already published [`v1.0.0`](http://esri.github.io/calcite-web/quick-reference/changelog/)