### PR TITLE
Radio button and checkbox iOS and alignment fixes

### DIFF
--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -267,6 +267,24 @@
       }
     }
   }
+  // rtl spacing
+  html[dir="rtl"] {
+    & input[type='radio'], & input[type='checkbox'] {
+      margin-right: .125rem;
+      margin-left: .5rem;
+    }
+    @supports (-ms-ime-align: auto) {
+      input[type='radio'], input[type='checkbox'] {
+        margin-left: .5rem;
+      }
+    }
+    // special style for iOS checked
+    @supports (-webkit-overflow-scrolling: touch) {
+      input[type='radio'], input[type='checkbox'] {
+        margin-left: 0;
+      }
+    }
+  }
 
   .fieldset-radio, .fieldset-checkbox {
     label {

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -195,6 +195,7 @@
     @include btn-small();
     font-family: inherit;
     margin: .5em 0;
+    -webkit-appearance: none;
   }
 
   ::-ms-value {
@@ -221,8 +222,8 @@
     @include left();
     width: 1rem;
     height: 1rem;
-    margin-top: .135rem;
-    margin-right: .125rem;
+    margin-top: .15rem;
+    margin-right: .5rem;
     margin-left: .125rem;
     line-height: 1.25rem;
     box-shadow: none;
@@ -239,6 +240,32 @@
   }
   input[type='radio'] {
     -webkit-appearance: radio;
+    -webkit-border-radius: 50%;
+    border-radius: 50%;
+  }
+  // alignment fixes for edge
+  @supports (-ms-ime-align: auto) {
+    input[type='radio'], input[type='checkbox'] {
+      margin-top: .35rem;
+      margin-right: .5rem;
+    }
+  }
+  // alignment fixes for ff
+  @supports (-moz-appearance:none) {
+    input[type='radio'], input[type='checkbox'] {
+      margin-top: .05rem;
+    }
+  }
+  // special style for iOS checked
+  @supports (-webkit-overflow-scrolling: touch) {
+    input[type='radio'], input[type='checkbox'] {
+      margin-top: .05rem;
+      margin-right: 0;
+      &:checked {
+        background-color:$Calcite_Blue_250;
+        border-color:$Calcite_Blue_a250;
+      }
+    }
   }
 
   .fieldset-radio, .fieldset-checkbox {

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -259,7 +259,7 @@
   // special style for iOS checked
   @supports (-webkit-overflow-scrolling: touch) {
     input[type='radio'], input[type='checkbox'] {
-      margin-top: .05rem;
+      margin-top: .075rem;
       margin-right: 0;
       &:checked {
         background-color:$Calcite_Blue_250;


### PR DESCRIPTION
Fixes for https://github.com/Esri/calcite-web/issues/861 ...

Makes radio inputs display as such on iOS
Browser-specific adjustments to make alignment more consistent
Fixed iOS display of input file upload button

Alignment aside, all browsers display these radios and checkboxes differently, could be a candidate for another pass down the road to make the styles themselves more consistent.