### PR TITLE
Dark Theme Docs Toggle

### DIFF
--- a/docs/source/assets/css/_doc.scss
+++ b/docs/source/assets/css/_doc.scss
@@ -1,0 +1,239 @@
+$include-content-family: true;
+$include-secondary-family: true;
+
+// Icons
+$include-calcite-icons: false;
+
+
+// Turn these on to test 960px grid
+// $container-width: 960px;
+
+// Use this to test dark theme
+// @import "calcite-web-dark";
+
+@import "calcite-web";
+@import "github";
+
+// Splashy banner stuff
+.bg-banner {
+  background: url('../img/docs/banner.svg') no-repeat center center $off-white;
+}
+
+.huge-text {
+  font-size: calc(4vw + 16px);
+  line-height: 1.25;
+}
+
+// Sub-Nav test Classes
+.sub-nav {
+  background-color: $darker-blue;
+}
+
+// Type Specimen Classes
+.type-sample {
+  @include font-size(10);
+  line-height: 1.15em;
+}
+
+// Modifier Classes
+.styleguide-modifiers {
+  @include clearfix();
+  background: $white;
+  .styleguide-modifier-example {
+    min-height: 2rem;
+    padding: .5em;
+    border: 1px solid $lightest-gray;
+    position: relative;
+    clear: both;
+    &:last-child {
+      border-radius: 0 0 3px 3px;
+    }
+    &:not(:last-of-type) {
+      border-bottom-width:0px;
+    }
+    &:first-child {
+      border-radius: 3px 3px 0 0;
+      .modifier-name {
+        border-radius: 0 3px 0 3px;
+      }
+    }
+    .modifier-name {
+      border-radius: 0 0 0 3px;
+      position: absolute;
+      top: -1px;
+      right: -1px;
+      @include font-size(-3);
+      padding-left: 3px;
+      padding-right: 3px;
+      z-index: 1;
+      @if ($include-right-to-left) {
+        html[dir="rtl"] & {
+          right: auto;
+          left: -1px;
+          border-radius: 0 0 3px 0;
+        }
+      }
+    }
+    .alert {
+      z-index: 0;
+    }
+  }
+}
+
+.styleguide-modifiers + pre {
+  margin-top: 0;
+  code {
+    border-top-width: 0px;
+    border-radius: 0 0 3px 3px;
+    max-height: 300px;
+  }
+}
+
+// Grid Test Classes
+.grid-example [class*="column-"],
+.grid-example .block, {
+  margin-top: 1em;
+  span {
+    width: 100%;
+    display: block;
+    color: $white;
+    background-color: rgba($blue, 0.6);
+    font-family: monospace;
+    padding-top: 2em;
+    padding-bottom: 2em;
+    text-align: center;
+  }
+}
+
+.html-sample {
+  max-height: 45vh;
+  overflow: scroll;
+}
+
+.nested-demo [class*="column-"] {
+  [class*="column-"] {
+    span {
+      background-color: rgba($blue, 0.4);
+    }
+    [class*="column-"] {
+      span {
+        background-color: rgba($blue, 0.2);
+      }
+      [class*="column-"] {
+        span {
+          background-color: rgba($blue, 0.1);
+        }
+      }
+    }
+  }
+}
+
+// Color Sample Classes
+
+.color-sample {
+  width: 100%;
+  height: 5*$baseline;
+  padding-top: .5rem;
+  &.white { background-color: $white; }
+  &.off-white { background-color: $off-white; }
+  &.lightest-gray { background-color: $lightest-gray; }
+  &.lighter-gray { background-color: $lighter-gray; }
+  &.light-gray { background-color: $light-gray; }
+  &.gray { background-color: $gray; }
+  &.dark-gray { background-color: $dark-gray; }
+  &.darker-gray { background-color: $darker-gray; }
+  &.darkest-gray { background-color: $darkest-gray; }
+  &.off-black { background-color: $off-black; }
+  &.black { background-color: $black; }
+  &.transparent-off-black { background-color: $transparent-off-black; }
+  &.transparent-black { background-color: $transparent-black; }
+  &.lightest-blue { background-color: $lightest-blue; }
+  &.lighter-blue { background-color: $lighter-blue; }
+  &.light-blue { background-color: $light-blue; }
+  &.blue { background-color: $blue; }
+  &.dark-blue { background-color: $dark-blue; }
+  &.light-green { background-color: $light-green; }
+  &.green { background-color: $green; }
+  &.dark-green { background-color: $dark-green; }
+  &.light-red { background-color: $light-red; }
+  &.red { background-color: $red; }
+  &.dark-red { background-color: $dark-red; }
+  &.light-orange { background-color: $light-orange; }
+  &.orange { background-color: $orange; }
+  &.dark-orange { background-color: $dark-orange; }
+  &.light-yellow { background-color: $light-yellow; }
+  &.yellow { background-color: $yellow; }
+  &.dark-yellow { background-color: $dark-yellow; }
+  &.light-purple { background-color: $light-purple; }
+  &.purple { background-color: $purple; }
+  &.dark-purple { background-color: $dark-purple; }
+  &.light-brown { background-color: $light-brown; }
+  &.brown { background-color: $brown; }
+  &.dark-brown { background-color: $dark-brown; }
+}
+
+.code-area {
+  @include code-face();
+  padding: .25rem;
+  border-radius: 3px;
+  border: 1px solid $lightest-gray;
+  color: $darkest-gray;
+  background-color: $off-white;
+  white-space: pre;
+  font-size: 0.85em;
+  line-height: 1.4rem;
+  padding: 1rem;
+  display: block;
+  overflow: auto;
+  max-width: 100%;
+}
+
+.icon-preview-link {
+  background-color: white;
+  color: $off-black;
+  padding-top: $baseline;
+  border: 1px solid $white;
+  cursor: pointer;
+  text-align: center;
+  white-space: normal;
+}
+
+.icon-preview-link:hover, .icon-preview-link:focus {
+  background-color: $off-white;
+  border: 1px solid $lightest-gray;
+  outline: none;
+  color: $off-black;
+}
+
+.icon-preview {
+  pointer-events: none;
+}
+
+.icon-wrap {
+  pointer-events: none;
+  display: block;
+}
+
+.icon-preview svg {
+  display: block;
+  margin: 0 auto;
+  pointer-events: none;
+}
+
+mark {
+  background-color: $lightest-blue;
+}
+
+.docs-link-icon {
+  height: 16px;
+  width: auto;
+  max-width: 40px;
+  margin-left: $baseline * 0.25;
+  vertical-align: middle;
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      margin-left: 0;
+      margin-right: $baseline * 0.25;
+    }
+  }
+}

--- a/docs/source/assets/css/_doc.scss
+++ b/docs/source/assets/css/_doc.scss
@@ -237,3 +237,8 @@ mark {
     }
   }
 }
+
+.docs-toggle-spacer {
+  padding-top: $baseline * .8;
+  padding-bottom: $baseline * .55;
+}

--- a/docs/source/assets/css/_doc.scss
+++ b/docs/source/assets/css/_doc.scss
@@ -39,6 +39,7 @@ $include-calcite-icons: false;
 .styleguide-modifiers {
   @include clearfix();
   background: $white;
+  overflow-x: scroll;
   .styleguide-modifier-example {
     min-height: 2rem;
     padding: .5em;

--- a/docs/source/assets/css/_theme.scss
+++ b/docs/source/assets/css/_theme.scss
@@ -1,0 +1,70 @@
+// animation overlays for switching themes
+.theme-dark-fade-in:after, .theme-light-fade-in:after {
+  content: "";
+  display: block;
+  position: fixed;
+  z-index: 10001;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+}
+.theme-dark-fade-in:after {
+  animation: fadeInDark ease-in 1s;
+  -webkit-animation: fadeInDark ease-in 1s;
+  -moz-animation: fadeInDark ease-in 1s;
+  -o-animation: fadeInDark ease-in 1s;
+  -ms-animation: fadeInDark ease-in 1s;
+  background-color: rgba($off-white, 1.0);
+  opacity: 0;
+}
+.theme-light-fade-in:after {
+  animation: fadeInLight ease-in 1s;
+  -webkit-animation: fadeInLight ease-in 1s;
+  -moz-animation: fadeInLight ease-in 1s;
+  -o-animation: fadeInLight ease-in 1s;
+  -ms-animation: fadeInLight ease-in 1s;
+  background-color: rgba($off-black, 1.0);
+  opacity: 0;
+}
+@keyframes fadeInLight {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-moz-keyframes fadeInLight {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-webkit-keyframes fadeInLight {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-o-keyframes fadeInLight {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-ms-keyframes fadeInLight {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@keyframes fadeInDark {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-moz-keyframes fadeInDark {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-webkit-keyframes fadeInDark {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-o-keyframes fadeInDark {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}
+@-ms-keyframes fadeInDark {
+  0% { opacity: 1.0; }
+  100% { opacity: 0; }
+}

--- a/docs/source/assets/css/_theme.scss
+++ b/docs/source/assets/css/_theme.scss
@@ -16,7 +16,7 @@
   -moz-animation: fadeInDark ease-in 1s;
   -o-animation: fadeInDark ease-in 1s;
   -ms-animation: fadeInDark ease-in 1s;
-  background-color: rgba($off-white, 1.0);
+  background-color: rgba(#fff, 1.0);
   opacity: 0;
 }
 .theme-light-fade-in:after {
@@ -25,7 +25,7 @@
   -moz-animation: fadeInLight ease-in 1s;
   -o-animation: fadeInLight ease-in 1s;
   -ms-animation: fadeInLight ease-in 1s;
-  background-color: rgba($off-black, 1.0);
+  background-color: rgba(#000, 1.0);
   opacity: 0;
 }
 @keyframes fadeInLight {

--- a/docs/source/assets/css/dark.scss
+++ b/docs/source/assets/css/dark.scss
@@ -2,5 +2,5 @@ $include-content-family: true;
 $include-secondary-family: true;
 $include-calcite-icons: false;
 
-@import "calcite-web";
+@import "calcite-web-dark";
 @import "doc";

--- a/docs/source/assets/css/extensions.scss
+++ b/docs/source/assets/css/extensions.scss
@@ -1,3 +1,4 @@
 @import "calcite-web-e-commerce";
 @import "calcite-web-marketing";
+@import "theme";
 

--- a/docs/source/assets/js/theme.js
+++ b/docs/source/assets/js/theme.js
@@ -1,4 +1,4 @@
-// Calcite Web Docs Theme Toggle
+// Calcite docs theme switcher
 (function () {
   var localStorageItem = 'calciteWebTheme';
   var themeDarkStylesheet = document.getElementById('calcite-theme-dark');
@@ -6,55 +6,44 @@
   var themeDarkAnimationClass = 'theme-dark-fade-in';
   var themeLightAnimationClass = 'theme-light-fade-in';
   var themeToggleEls = document.getElementsByClassName('docs-theme-toggle');
-  var themeToggles = Array.from(themeToggleEls);
+  var themeToggles = [];
+
+  // ie array wrangling
+  for (var i = 0; i < themeToggleEls.length; i++) { themeToggles.push(themeToggleEls[i]); }
 
   document.addEventListener('DOMContentLoaded', setThemeOnLoad);
-  themeToggles.forEach(el => el.addEventListener('click', changeTheme));
+  themeToggles.forEach(function (el) { return el.addEventListener('click', changeTheme); });
 
+  // set disabled attribute on load here as well as in markup for ff
   function setThemeOnLoad() {
-    // we need to set disabled attribute here as well as in markup for ff
-    if (localStorage.getItem(localStorageItem) == 'dark') {
-      console.log("page load im dark");
+    if (localStorage.getItem(localStorageItem) === 'dark') {
       themeDarkStylesheet.disabled = false;
       themeLightStylesheet.disabled = true;
-      themeToggles.forEach(el => el.setAttribute('checked', true));
-    }
-    else {
-      console.log("page load im light");
+      themeToggles.forEach(function (el) { return el.checked = true });
+    } else {
       themeLightStylesheet.disabled = false;
       themeDarkStylesheet.disabled = true;
+      themeToggles.forEach(function (el) { return el.checked = false });
     }
   }
 
-  function changeTheme(el) {
-    if (localStorage.getItem(localStorageItem) == 'dark') {
+  function changeTheme() {
+    if (localStorage.getItem(localStorageItem) === 'dark' || localStorage.getItem(localStorageItem) === null) {
       localStorage.setItem(localStorageItem, 'light');
-      var currentTheme = localStorage.getItem(localStorageItem);
       themeLightStylesheet.disabled = false;
       themeDarkStylesheet.disabled = true;
       document.body.classList.remove(themeDarkAnimationClass);
       document.body.classList.add(themeLightAnimationClass);
-      themeToggles.forEach(el => el.setAttribute('checked', false));
-      setTimeout(function () {
-        document.body.classList.remove(themeLightAnimationClass);
-      }, 2000);
-      console.log(currentTheme);
-    }
-    else {
+      themeToggles.forEach(function (el) { return el.checked = false });
+      setTimeout(function () { document.body.classList.remove(themeLightAnimationClass); }, 2000);
+    } else {
       localStorage.setItem(localStorageItem, 'dark');
-      var currentTheme = localStorage.getItem(localStorageItem);
       themeDarkStylesheet.disabled = false;
       themeLightStylesheet.disabled = true;
       document.body.classList.remove(themeLightAnimationClass);
       document.body.classList.add(themeDarkAnimationClass);
-      themeToggles.forEach(el => el.setAttribute('checked', true));
-      setTimeout(function () {
-        themeLightStylesheet.disabled = true;
-      }, 10);
-      setTimeout(function () {
-        document.body.classList.remove(themeDarkAnimationClass);
-      }, 2000);
-      console.log(currentTheme);
+      themeToggles.forEach(function (el) { return el.checked = true });
+      setTimeout(function () { document.body.classList.remove(themeDarkAnimationClass); }, 2000);
     }
   }
 })();

--- a/docs/source/assets/js/theme.js
+++ b/docs/source/assets/js/theme.js
@@ -1,0 +1,60 @@
+// Calcite Web Docs Theme Toggle
+(function () {
+  var localStorageItem = 'calciteWebTheme';
+  var themeDarkStylesheet = document.getElementById('calcite-theme-dark');
+  var themeLightStylesheet = document.getElementById('calcite-theme-light');
+  var themeDarkAnimationClass = 'theme-dark-fade-in';
+  var themeLightAnimationClass = 'theme-light-fade-in';
+  var themeToggleEls = document.getElementsByClassName('docs-theme-toggle');
+  var themeToggles = Array.from(themeToggleEls);
+
+  document.addEventListener('DOMContentLoaded', setThemeOnLoad);
+  themeToggles.forEach(el => el.addEventListener('click', changeTheme));
+
+  function setThemeOnLoad() {
+    // we need to set disabled attribute here as well as in markup for ff
+    if (localStorage.getItem(localStorageItem) == 'dark') {
+      console.log("page load im dark");
+      themeDarkStylesheet.disabled = false;
+      themeLightStylesheet.disabled = true;
+      themeToggles.forEach(el => el.setAttribute('checked', true));
+    }
+    else {
+      console.log("page load im light");
+      themeLightStylesheet.disabled = false;
+      themeDarkStylesheet.disabled = true;
+    }
+  }
+
+  function changeTheme(el) {
+    if (localStorage.getItem(localStorageItem) == 'dark') {
+      localStorage.setItem(localStorageItem, 'light');
+      var currentTheme = localStorage.getItem(localStorageItem);
+      themeLightStylesheet.disabled = false;
+      themeDarkStylesheet.disabled = true;
+      document.body.classList.remove(themeDarkAnimationClass);
+      document.body.classList.add(themeLightAnimationClass);
+      themeToggles.forEach(el => el.setAttribute('checked', false));
+      setTimeout(function () {
+        document.body.classList.remove(themeLightAnimationClass);
+      }, 2000);
+      console.log(currentTheme);
+    }
+    else {
+      localStorage.setItem(localStorageItem, 'dark');
+      var currentTheme = localStorage.getItem(localStorageItem);
+      themeDarkStylesheet.disabled = false;
+      themeLightStylesheet.disabled = true;
+      document.body.classList.remove(themeLightAnimationClass);
+      document.body.classList.add(themeDarkAnimationClass);
+      themeToggles.forEach(el => el.setAttribute('checked', true));
+      setTimeout(function () {
+        themeLightStylesheet.disabled = true;
+      }, 10);
+      setTimeout(function () {
+        document.body.classList.remove(themeDarkAnimationClass);
+      }, 2000);
+      console.log(currentTheme);
+    }
+  }
+})();

--- a/docs/source/assets/js/theme.js
+++ b/docs/source/assets/js/theme.js
@@ -5,11 +5,7 @@
   var themeLightStylesheet = document.getElementById('calcite-theme-light');
   var themeDarkAnimationClass = 'theme-dark-fade-in';
   var themeLightAnimationClass = 'theme-light-fade-in';
-  var themeToggleEls = document.getElementsByClassName('docs-theme-toggle');
-  var themeToggles = [];
-
-  // ie array wrangling
-  for (var i = 0; i < themeToggleEls.length; i++) { themeToggles.push(themeToggleEls[i]); }
+  var themeToggles = Array.prototype.slice.call(document.querySelectorAll('.docs-theme-toggle'));
 
   document.addEventListener('DOMContentLoaded', setThemeOnLoad);
   themeToggles.forEach(function (el) { return el.addEventListener('click', changeTheme); });

--- a/docs/source/documentation/components/sample-code/_form-overview.html
+++ b/docs/source/documentation/components/sample-code/_form-overview.html
@@ -33,7 +33,7 @@
   </label>
 <label class="toggle-switch">
   <input type="checkbox" class="toggle-switch-input">
-  <span class="toggle-switch-track toggle-switch-inline"></span>
+  <span class="toggle-switch-track margin-right-1"></span>
   <span class="toggle-switch-label font-size--1">Inline example</span>
 </label>
 <label class="toggle-switch toggle-switch-destructive clearfix">

--- a/docs/source/documentation/components/sample-code/_switches.html
+++ b/docs/source/documentation/components/sample-code/_switches.html
@@ -1,6 +1,6 @@
 <label class="toggle-switch {{ modifier }}">
   <input type="checkbox" class="toggle-switch-input">
-  <span class="toggle-switch-track toggle-switch-inline"></span>
+  <span class="toggle-switch-track margin-right-1"></span>
   <span class="toggle-switch-label font-size--1">Inline example</span>
 </label>
 <label class="toggle-switch {{ modifier }} clearfix">

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -23,9 +23,9 @@
 
   <!-- stylesheets -->
   {% block head %}
-  <link rel="stylesheet" href="{{relativePath}}/assets/css/all.css" id="calcite-theme-light" name="theme-light">
-  <link rel="stylesheet" href="{{relativePath}}/assets/css/dark.css" id="calcite-theme-dark" name="theme-dark" disabled>
   <link rel="stylesheet" href="{{relativePath}}/assets/css/extensions.css">
+  <link rel="stylesheet" href="{{relativePath}}/assets/css/all.css" id="calcite-theme-light" name="theme-light" title="theme-light">
+  <link rel="stylesheet" href="{{relativePath}}/assets/css/dark.css" id="calcite-theme-dark" name="theme-dark" title="theme-dark" disabled>
   {% for name in css %}
   <link rel="stylesheet" href="{{relativePath}}/assets/css/{{name}}.css">
   {% endfor %}
@@ -56,8 +56,8 @@
           <a class="side-nav-link">
             <label class="toggle-switch leader-0 trailer-0">
               <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
-              <span class="toggle-switch-track toggle-switch-inline"></span>
-              <span class="toggle-switch-label font-size--1">Daaark</span>
+              <span class="toggle-switch-track margin-right-half"></span>
+              <span class="toggle-switch-label font-size--2">Dark Mode</span>
             </label>
           </a>
         </aside>
@@ -75,8 +75,8 @@
           <a class="side-nav-link">
             <label class="toggle-switch leader-0 trailer-0">
               <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
-              <span class="toggle-switch-track toggle-switch-inline"></span>
-              <span class="toggle-switch-label font-size--1">Daaark</span>
+              <span class="toggle-switch-track margin-right-half"></span>
+              <span class="toggle-switch-label font-size--2">Dark Mode</span>
             </label>
           </a>
         </aside>
@@ -116,11 +116,11 @@
               <a href="{{relativePath}}/quick-reference" class="{% if isQuickRef %}is-active {% endif %}top-nav-link">Quick Reference</a>
             </nav>
             <nav class="class-top-nav-list right" role="navigation" aria-labelledby="usernav">
-              <a class="top-nav-link padding-leader-1 padding-trailer-half">
-                <label class="toggle-switch leader-0 trailer-0">
+              <a class="top-nav-link padding-leader-0 padding-trailer-0 trailer-0 margin-right-1">
+                <label class="toggle-switch trailer-0 docs-toggle-spacer">
                   <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
-                  <span class="toggle-switch-track toggle-switch-inline"></span>
-                  <span class="toggle-switch-label font-size--1">Daaark</span>
+                  <span class="toggle-switch-track margin-right-half"></span>
+                  <span class="toggle-switch-labe">Dark Mode</span>
                 </label>
               </a>
               <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -45,7 +45,6 @@
      ↳ patterns → _drawers.md
    -->
    <div class="drawer drawer-left js-drawer" data-drawer="top-nav">
-    <!-- <nav class="drawer-nav" role="navigation" aria-labelledby="topnavdrawerleft"> -->
       <nav class="drawer-nav" role="navigation">
         <aside class="side-nav">
           <h2 class="side-nav-title">Calcite Web</h2>

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -57,7 +57,7 @@
             <label class="toggle-switch leader-0 trailer-0">
               <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
               <span class="toggle-switch-track margin-right-half"></span>
-              <span class="toggle-switch-label font-size--2">Dark Mode</span>
+              <span class="toggle-switch-label font-size--2">Dark Theme</span>
             </label>
           </a>
         </aside>
@@ -76,7 +76,7 @@
             <label class="toggle-switch leader-0 trailer-0">
               <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
               <span class="toggle-switch-track margin-right-half"></span>
-              <span class="toggle-switch-label font-size--2">Dark Mode</span>
+              <span class="toggle-switch-label font-size--2">Dark Theme</span>
             </label>
           </a>
         </aside>
@@ -120,7 +120,7 @@
                 <label class="toggle-switch trailer-0 docs-toggle-spacer">
                   <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
                   <span class="toggle-switch-track margin-right-half"></span>
-                  <span class="toggle-switch-labe">Dark Mode</span>
+                  <span class="toggle-switch-labe">Dark Theme</span>
                 </label>
               </a>
               <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -2,34 +2,34 @@
 <!--[if lt IE 9]>  <html class="ie lt-ie9 ie8"> <![endif]-->
 <!--[if IE 9]>     <html class="ie ie9"> <![endif]-->
 <!--[if !IE]><!--> <html lang="en"> <!--<![endif]-->
-  <head>
+<head>
 
-    <!-- Set encoding -->
-    <meta charset="utf-8">
+  <!-- Set encoding -->
+  <meta charset="utf-8">
 
-    <!-- Always force latest IE rendering engine or request Chrome Frame -->
-    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
-    <meta name="viewport" content="width=device-width, user-scalable=no">
+  <!-- Always force latest IE rendering engine or request Chrome Frame -->
+  <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
+  <meta name="viewport" content="width=device-width, user-scalable=no">
 
-    <!-- Use title from page frontmatter -->
-    <title>{{title}} | Esri Design Patterns</title>
+  <!-- Use title from page frontmatter -->
+  <title>{{title}} | Esri Design Patterns</title>
 
-    {% if relativePath == '' %}
-      {% set relativePath = '.' %}
-    {% endif %}
+  {% if relativePath == '' %}
+  {% set relativePath = '.' %}
+  {% endif %}
 
-    <!-- Link to favicon -->
-    <link rel="shortcut icon" href="{{relativePath}}/assets/img/favicon.ico">
+  <!-- Link to favicon -->
+  <link rel="shortcut icon" href="{{relativePath}}/assets/img/favicon.ico">
 
-    <!-- stylesheets -->
-    {% block head %}
-      <link rel="stylesheet" href="{{relativePath}}/assets/css/all.css">
-      <link rel="stylesheet" href="{{relativePath}}/assets/css/extensions.css">
-      {% for name in css %}
-        <link rel="stylesheet" href="{{relativePath}}/assets/css/{{name}}.css">
-      {% endfor %}
-    {% endblock %}
-
+  <!-- stylesheets -->
+  {% block head %}
+  <link rel="stylesheet" href="{{relativePath}}/assets/css/all.css" id="calcite-theme-light" name="theme-light">
+  <link rel="stylesheet" href="{{relativePath}}/assets/css/dark.css" id="calcite-theme-dark" name="theme-dark" disabled>
+  <link rel="stylesheet" href="{{relativePath}}/assets/css/extensions.css">
+  {% for name in css %}
+  <link rel="stylesheet" href="{{relativePath}}/assets/css/{{name}}.css">
+  {% endfor %}
+  {% endblock %}
     <!--[if IE]>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/selectivizr/1.0.2/selectivizr-min.js"></script>
@@ -43,9 +43,9 @@
     └─────────┘
      ↳ http://esri.github.io/calcite-web/patterns/#drawers
      ↳ patterns → _drawers.md
-    -->
-    <div class="drawer drawer-left js-drawer" data-drawer="top-nav">
-      <!-- <nav class="drawer-nav" role="navigation" aria-labelledby="topnavdrawerleft"> -->
+   -->
+   <div class="drawer drawer-left js-drawer" data-drawer="top-nav">
+    <!-- <nav class="drawer-nav" role="navigation" aria-labelledby="topnavdrawerleft"> -->
       <nav class="drawer-nav" role="navigation">
         <aside class="side-nav">
           <h2 class="side-nav-title">Calcite Web</h2>
@@ -53,6 +53,13 @@
           <a href="{{relativePath}}/examples/" class="side-nav-link">Examples</a>
           <a href="{{relativePath}}/guides/" class="side-nav-link">Guides</a>
           <a href="{{relativePath}}/quick-reference/" class="side-nav-link">Quick Reference</a>
+          <a class="side-nav-link">
+            <label class="toggle-switch leader-0 trailer-0">
+              <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
+              <span class="toggle-switch-track toggle-switch-inline"></span>
+              <span class="toggle-switch-label font-size--1">Daaark</span>
+            </label>
+          </a>
         </aside>
       </nav>
     </div>
@@ -65,6 +72,13 @@
           <a href="{{relativePath}}/examples/" class="side-nav-link">Examples</a>
           <a href="{{relativePath}}/guides/" class="side-nav-link">Guides</a>
           <a href="{{relativePath}}/quick-reference/" class="side-nav-link">Quick Reference</a>
+          <a class="side-nav-link">
+            <label class="toggle-switch leader-0 trailer-0">
+              <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
+              <span class="toggle-switch-track toggle-switch-inline"></span>
+              <span class="toggle-switch-label font-size--1">Daaark</span>
+            </label>
+          </a>
         </aside>
       </nav>
     </div>
@@ -73,146 +87,152 @@
       <!--
       ┌────────┐
       │ Search │
-      -->
-      <div class="js-search search-overlay">
-        <div class="search-content" role="dialog" aria-labelledby="search" role="dialog">
-          <form method="GET" action="{{relativePath}}/search/">
-            <label>
-              Search Calcite Web
-              <input class="search-input js-search-input" type="search" placeholder='Search' name="q" autocomplete="off">
-            </label>
-            <button type="submit" class="btn btn-large right">Search</button>
-          </form>
-        </div>
+    -->
+    <div class="js-search search-overlay">
+      <div class="search-content" role="dialog" aria-labelledby="search" role="dialog">
+        <form method="GET" action="{{relativePath}}/search/">
+          <label>
+            Search Calcite Web
+            <input class="search-input js-search-input" type="search" placeholder='Search' name="q" autocomplete="off">
+          </label>
+          <button type="submit" class="btn btn-large right">Search</button>
+        </form>
       </div>
-
-      <!-- Sample HTML -->
-      <header class="top-nav">
-        <div class="grid-container">
-          <div class="column-24">
-            <!-- desktop sized navigation -->
-            <div class="tablet-hide">
-              <!-- logo / home -->
-              <a href="{{relativePath}}/" class="top-nav-title">Calcite Web</a>
-              <!-- primary navigation sections -->
-              <nav class="top-nav-list" role="navigation">
-                <a href="{{relativePath}}/documentation" class="{% if isDocumentation %}is-active {% endif %}top-nav-link">Documentation</a>
-                <a href="{{relativePath}}/examples" class="{% if isExample %}is-active {% endif %}top-nav-link">Examples</a>
-                <a href="{{relativePath}}/guides" class="{% if isGuide %}is-active {% endif %}top-nav-link">Guides</a>
-                <a href="{{relativePath}}/quick-reference" class="{% if isQuickRef %}is-active {% endif %}top-nav-link">Quick Reference</a>
-              </nav>
-              <nav class="class-top-nav-list right" role="navigation" aria-labelledby="usernav">
-                <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon js-search-icon">
-                    <path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/>
-                  </svg>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon js-close-icon hide">
-                    <path d="M18.404 16l9.9 9.9-2.404 2.404-9.9-9.9-9.9 9.9L3.696 25.9l9.9-9.9-9.9-9.898L6.1 3.698l9.9 9.899 9.9-9.9 2.404 2.406-9.9 9.898z"/>
-                  </svg>
-                </button>
-              </nav>
-            </div>
-
-            <!-- tablet and mobile sized navigation -->
-            <div class="tablet-show top-nav-flex">
-              <!-- open primary navigation drawer -->
-              <nav class="top-nav-flex-list" role="navigation" aria-labelledby="topnav">
-                <a href="/" class="top-nav-link js-drawer-toggle" data-drawer="top-nav">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 -4 32 36" class="svg-icon"><path d="M28 3.5A2.5 2.5 0 0 1 25.5 6h-21A2.5 2.5 0 0 1 2 3.5v-1A2.5 2.5 0 0 1 4.5 0h21A2.5 2.5 0 0 1 28 2.5v1zm0 11a2.5 2.5 0 0 0-2.5-2.5h-21A2.5 2.5 0 0 0 2 14.5v1A2.5 2.5 0 0 0 4.5 18h21a2.5 2.5 0 0 0 2.5-2.5v-1zm0 12a2.5 2.5 0 0 0-2.5-2.5h-21A2.5 2.5 0 0 0 2 26.5v1A2.5 2.5 0 0 0 4.5 30h21a2.5 2.5 0 0 0 2.5-2.5v-1z"/></svg>
-                </a>
-              </nav>
-              <!-- logo / home -->
-              <header class="top-nav-flex-title">
-                <a href="/" class="top-nav-link">Calcite Web</span></a>
-              </header>
-              <nav class="top-nav-flex-list class-top-nav-list text-right" role="navigation" aria-labelledby="usernav">
-                <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 -4 32 36" class="svg-icon js-search-icon">
-                    <path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/>
-                  </svg>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 -4 32 36" class="svg-icon js-close-icon hide">
-                    <path d="M18.404 16l9.9 9.9-2.404 2.404-9.9-9.9-9.9 9.9L3.696 25.9l9.9-9.9-9.9-9.898L6.1 3.698l9.9 9.899 9.9-9.9 2.404 2.406-9.9 9.898z"/>
-                  </svg>
-                </button>
-              </nav>
-            </div>
-          </div>
-
-        </div>
-      </header>
-
-
-      <!-- Secondary Nav Pattern -->
-      <!-- what -->
-      {% block subnav%}{% endblock %}
-
-      <!-- content of each page will go here -->
-      {% block content%}{% endblock %}
     </div>
 
-    {% block footer %}
-
-    <!-- Footer Pattern -->
-    <footer class="footer leader-3 link-dark-gray" role="contentinfo">
+    <!-- Sample HTML -->
+    <header class="top-nav">
       <div class="grid-container">
-          <nav class="column-6">
-            <h6>Styleguides</h6>
-            <ul class="list-plain">
-              <li><a href="{{relativePath}}/guides/code/javascript/">JavaScript</a></li>
-              <li><a href="{{relativePath}}/guides/code/css/">CSS</a></li>
-              <li><a href="{{relativePath}}/guides/code/html/">HTML</a></li>
-            </ul>
-          </nav>
+        <div class="column-24">
+          <!-- desktop sized navigation -->
+          <div class="tablet-hide">
+            <!-- logo / home -->
+            <a href="{{relativePath}}/" class="top-nav-title">Calcite Web</a>
+            <!-- primary navigation sections -->
+            <nav class="top-nav-list" role="navigation">
+              <a href="{{relativePath}}/documentation" class="{% if isDocumentation %}is-active {% endif %}top-nav-link">Documentation</a>
+              <a href="{{relativePath}}/examples" class="{% if isExample %}is-active {% endif %}top-nav-link">Examples</a>
+              <a href="{{relativePath}}/guides" class="{% if isGuide %}is-active {% endif %}top-nav-link">Guides</a>
+              <a href="{{relativePath}}/quick-reference" class="{% if isQuickRef %}is-active {% endif %}top-nav-link">Quick Reference</a>
+            </nav>
+            <nav class="class-top-nav-list right" role="navigation" aria-labelledby="usernav">
+              <a class="top-nav-link padding-leader-1 padding-trailer-half">
+                <label class="toggle-switch leader-0 trailer-0">
+                  <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
+                  <span class="toggle-switch-track toggle-switch-inline"></span>
+                  <span class="toggle-switch-label font-size--1">Daaark</span>
+                </label>
+              </a>
+              <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon js-search-icon">
+                  <path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/>
+                </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon js-close-icon hide">
+                  <path d="M18.404 16l9.9 9.9-2.404 2.404-9.9-9.9-9.9 9.9L3.696 25.9l9.9-9.9-9.9-9.898L6.1 3.698l9.9 9.899 9.9-9.9 2.404 2.406-9.9 9.898z"/>
+                </svg>
+              </button>
+            </nav>
+          </div>
 
-          <nav class="column-6">
-            <h6>Resources</h6>
-            <ul class="list-plain">
-              <li><a href="{{relativePath}}/guides/migration-guide/">Migration Guide</a></li>
-              <li><a href="https://github.com/Esri/calcite-web/releases/">Releases</a></li>
-              <li><a href="https://github.com/Esri/calcite-web/blob/master/CONTRIBUTING.md">Contributing</a></li>
-              <li><a href="https://github.com/Esri/calcite-web/issues/">Issues</a></li>
-              <li><a href="https://github.com/Esri/calcite-web/">GitHub</a></li>
-            </ul>
-          </nav>
-
-          <nav class="column-6">
-            <h6>Presentations</h6>
-            <ul class="list-plain">
-              <li><a href="{{relativePath}}/presentations/calcite-web-primer/">Calcite Web: A Primer</a></li>
-              <li><a href="{{relativePath}}/presentations/calcite-web-deep-dive/">Calcite Web: Deep Dive</a></li>
-            </ul>
-          </nav>
-
-          <nav class="column-6">
-            <a class="esri-logo" href="http://esri.com" aria-label="Esri Home"></a>
-            <section class="footer-social-nav leader-1">
-              <a class="icon-social-twitter" aria-label="Esri on Twitter"  href="https://twitter.com/Esri/"></a>
-              <a class="icon-social-facebook" aria-label="Esri on Facebook"  href="https://www.facebook.com/esrigis/"></a>
-              <a class="icon-social-instagram" aria-label="Esri on Instagram"  href="https://instagram.com/esrigram/"></a>
-              <a class="icon-social-github" aria-label="Esri on GitHub"  href="http://esri.github.com/"></a>
-              <a class="icon-social-contact" aria-label="Contact Esri"  href="http://www.esri.com/about-esri/contact/"></a>
-            </section>
-          </nav>
-
-          <div class="column-24 leader-1">
-            <p><small>Copyright © 2018 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+          <!-- tablet and mobile sized navigation -->
+          <div class="tablet-show top-nav-flex">
+            <!-- open primary navigation drawer -->
+            <nav class="top-nav-flex-list" role="navigation" aria-labelledby="topnav">
+              <a href="/" class="top-nav-link js-drawer-toggle" data-drawer="top-nav">
+                <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 -4 32 36" class="svg-icon"><path d="M28 3.5A2.5 2.5 0 0 1 25.5 6h-21A2.5 2.5 0 0 1 2 3.5v-1A2.5 2.5 0 0 1 4.5 0h21A2.5 2.5 0 0 1 28 2.5v1zm0 11a2.5 2.5 0 0 0-2.5-2.5h-21A2.5 2.5 0 0 0 2 14.5v1A2.5 2.5 0 0 0 4.5 18h21a2.5 2.5 0 0 0 2.5-2.5v-1zm0 12a2.5 2.5 0 0 0-2.5-2.5h-21A2.5 2.5 0 0 0 2 26.5v1A2.5 2.5 0 0 0 4.5 30h21a2.5 2.5 0 0 0 2.5-2.5v-1z"/></svg>
+              </a>
+            </nav>
+            <!-- logo / home -->
+            <header class="top-nav-flex-title">
+              <a href="/" class="top-nav-link">Calcite Web</span></a>
+            </header>
+            <nav class="top-nav-flex-list class-top-nav-list text-right" role="navigation" aria-labelledby="usernav">
+              <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">
+                <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 -4 32 36" class="svg-icon js-search-icon">
+                  <path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/>
+                </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 -4 32 36" class="svg-icon js-close-icon hide">
+                  <path d="M18.404 16l9.9 9.9-2.404 2.404-9.9-9.9-9.9 9.9L3.696 25.9l9.9-9.9-9.9-9.898L6.1 3.698l9.9 9.899 9.9-9.9 2.404 2.406-9.9 9.898z"/>
+                </svg>
+              </button>
+            </nav>
           </div>
         </div>
-
       </div>
-    </footer>
+    </header>
 
-    <script src="{{relativePath}}/assets/js/libs/calcite-web.js"></script>
-    <script src="{{relativePath}}/assets/js/libs/calcite-web-marketing.js"></script>
 
-    <script src="{{relativePath}}/assets/js/all.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.12/clipboard.min.js"></script>
+    <!-- Secondary Nav Pattern -->
+    <!-- what -->
+    {% block subnav%}{% endblock %}
 
-    {% endblock %}
+    <!-- content of each page will go here -->
+    {% block content%}{% endblock %}
+  </div>
 
-    {% for name in js %}
-      <script src="{{relativePath}}/assets/js/{{name}}.js"></script>
-    {% endfor %}
+  {% block footer %}
 
-  </body>
+  <!-- Footer Pattern -->
+  <footer class="footer leader-3 link-dark-gray" role="contentinfo">
+    <div class="grid-container">
+      <nav class="column-6">
+        <h6>Styleguides</h6>
+        <ul class="list-plain">
+          <li><a href="{{relativePath}}/guides/code/javascript/">JavaScript</a></li>
+          <li><a href="{{relativePath}}/guides/code/css/">CSS</a></li>
+          <li><a href="{{relativePath}}/guides/code/html/">HTML</a></li>
+        </ul>
+      </nav>
+
+      <nav class="column-6">
+        <h6>Resources</h6>
+        <ul class="list-plain">
+          <li><a href="{{relativePath}}/guides/migration-guide/">Migration Guide</a></li>
+          <li><a href="https://github.com/Esri/calcite-web/releases/">Releases</a></li>
+          <li><a href="https://github.com/Esri/calcite-web/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/Esri/calcite-web/issues/">Issues</a></li>
+          <li><a href="https://github.com/Esri/calcite-web/">GitHub</a></li>
+        </ul>
+      </nav>
+
+      <nav class="column-6">
+        <h6>Presentations</h6>
+        <ul class="list-plain">
+          <li><a href="{{relativePath}}/presentations/calcite-web-primer/">Calcite Web: A Primer</a></li>
+          <li><a href="{{relativePath}}/presentations/calcite-web-deep-dive/">Calcite Web: Deep Dive</a></li>
+        </ul>
+      </nav>
+
+      <nav class="column-6">
+        <a class="esri-logo" href="http://esri.com" aria-label="Esri Home"></a>
+        <section class="footer-social-nav leader-1">
+          <a class="icon-social-twitter" aria-label="Esri on Twitter"  href="https://twitter.com/Esri/"></a>
+          <a class="icon-social-facebook" aria-label="Esri on Facebook"  href="https://www.facebook.com/esrigis/"></a>
+          <a class="icon-social-instagram" aria-label="Esri on Instagram"  href="https://instagram.com/esrigram/"></a>
+          <a class="icon-social-github" aria-label="Esri on GitHub"  href="http://esri.github.com/"></a>
+          <a class="icon-social-contact" aria-label="Contact Esri"  href="http://www.esri.com/about-esri/contact/"></a>
+        </section>
+      </nav>
+
+      <div class="column-24 leader-1">
+        <p><small>Copyright © 2018 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+      </div>
+    </div>
+
+  </div>
+</footer>
+
+<script src="{{relativePath}}/assets/js/theme.js"></script>
+<script src="{{relativePath}}/assets/js/libs/calcite-web.js"></script>
+<script src="{{relativePath}}/assets/js/libs/calcite-web-marketing.js"></script>
+<script src="{{relativePath}}/assets/js/all.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.12/clipboard.min.js"></script>
+
+{% endblock %}
+
+{% for name in js %}
+<script src="{{relativePath}}/assets/js/{{name}}.js"></script>
+{% endfor %}
+
+</body>
 </html>

--- a/docs/source/table_of_contents.yml
+++ b/docs/source/table_of_contents.yml
@@ -527,9 +527,7 @@ components:
         - title: 'Sliders'
           link: sliders
           status: 'complete'
-          classes:
-          modifiers:
-            - false
+          modifiers: false
         - title: 'Switches'
           link: switches
           status: 'complete'

--- a/lib/sass/calcite-web/components/_sliders.scss
+++ b/lib/sass/calcite-web/components/_sliders.scss
@@ -7,17 +7,17 @@
 // variables
 $range-border: 1px solid transparent;
 $track-bgcolor: $Calcite_Gray_350;
-$track-height: 3px;
+$track-height: 2px;
 $track-hover-bgcolor: $Calcite_Gray_400;
 $track-active-bgcolor: $Calcite_Gray_450;
 // $track-progress-bgcolor: $Brand_Blue_200;
 $thumb-height: 18px;
 $thumb-width: 18px;
-$thumb-border: 3px solid;
-$thumb-border-color: $Calcite_Gray_400;
+$thumb-border: 2px solid;
+$thumb-border-color: $Calcite_Gray_450;
 $thumb-border-hover-color: $Brand_Blue_200;
-$thumb-shadow-hover: 0 0 4px 2px rgba($Calcite_Gray_350, 0.8);
-$thumb-shadow-active: 0 0 4px 2px rgba($Calcite_Blue_250, 0.8);
+$thumb-shadow-hover: 0 0 4px 1px rgba($Calcite_Gray_350, 0.9);
+$thumb-shadow-active: 0 0 4px 1px rgba($Calcite_Blue_250, 0.9);
 $thumb-bg-default: $white;
 $thumb-bg-hover: $Brand_Blue_200;
 $thumb-bg-active: $Calcite_Blue_a250;
@@ -143,13 +143,12 @@ $thumb-bg-active: $Calcite_Blue_a250;
       margin-top: -9px;
     }
   }
-
   // ff styles
   input[type="range"]::-moz-range-track { @include track-style; }
   input[type="range"]::-moz-range-thumb {
     @include thumb-style;
-    height: 13px;
-    width: 13px;
+    height: 14px;
+    width: 14px;
     &:hover { @include thumb-hover-style; }
     &:focus, &:active {
       @include thumb-focus-style;
@@ -169,8 +168,8 @@ $thumb-bg-active: $Calcite_Blue_a250;
 
   input[type="range"]::-ms-thumb {
     @include thumb-style;
-    height: 12px;
-    width: 12px;
+    height: 14px;
+    width: 14px;
     margin-top: 0px;
     &:hover { @include thumb-hover-style; }
     &:focus, &:active {

--- a/lib/sass/calcite-web/components/_switches.scss
+++ b/lib/sass/calcite-web/components/_switches.scss
@@ -4,33 +4,33 @@
 //  ↳ http: //esri.github.io/calcite-web/documentation/components/#switches
 //  ↳ components → _switches.md
 // variables
-$switch-width: 2.5rem;
-$switch-height: 1.25rem;
+$switch-width: 36px;
+$switch-height: 20px;
 $switch-bg: $Calcite_Gray_150;
 $switch-border-color: $Calcite_Gray_350;
-$switch-hover-bg: $Calcite_Gray_200;
+$switch-hover-bg: $Calcite_Gray_250;
 $switch-hover-border-color: $Calcite_Gray_350;
-$switch-checked-bg: $Calcite_Blue_100;
-$switch-checked-border-color: $Calcite_Blue_200;
-$switch-focus-shadow: 0 0 4px 1px rgba($Calcite_Gray_350,0.8);
-$switch-focus-checked-shadow: 0 0 4px 1px rgba($Calcite_Blue_200,0.8);
-$switch-focus-destructive-checked-shadow: 0 0 4px 1px rgba($Calcite_Red_200,0.8);
-$handle-size: 13px;
-$handle-top-distance: 1px;
-$handle-edge-distance: 2px;
-$handle-active-edge-distance: 4px;
+$switch-checked-bg: $blue;
+$switch-checked-border-color: $dark-blue;
+$switch-focus-shadow: 0 0 4px 2px rgba($Calcite_Gray_350,0.9);
+$switch-focus-checked-shadow: 0 0 4px 2px rgba($Calcite_Blue_200,0.9);
+$switch-focus-destructive-checked-shadow: 0 0 4px 2px rgba($Calcite_Red_200,0.9);
+$handle-size: 18px;
+$handle-top-distance: -1px;
+$handle-edge-distance: -1px;
+$handle-active-edge-distance: 1px;
 $handle-bg: $white;
-$handle-border-color: $Calcite_Gray_400;
-$handle-shadow: 0 1px 1px 0px rgba($darkest-gray,0.1);
+$handle-border-color: $Calcite_Gray_450;
+$handle-shadow: 0 1px 1px 0px rgba($darkest-gray,0.2);
 $handle-hover-border-color: $Calcite_Blue_a200;
 $handle-hover-shadow: 0 1px 2px 0px rgba($darkest-gray,0.2);
-$handle-checked-border-color: $Calcite_Blue_a250;
+$handle-checked-border-color: $dark-blue;
 $handle-checked-shadow: 0 2px 1px 0px rgba($darkest-gray,0.2);
 $handle-active-shadow: 0 3px 1px 0px rgba($darkest-gray,0.2);
-$switch-destructive-checked-bg: $Calcite_Red_100;
-$switch-destructive-checked-border-color: $Calcite_Red_150;
+$switch-destructive-checked-bg: $Calcite_Red_a200;
+$switch-destructive-checked-border-color: $Calcite_Red_a250;
 $handle-destructive-hover-border-color: $Calcite_Red_a200;
-$handle-destructive-checked-border-color: $Calcite_Red_a200;
+$handle-destructive-checked-border-color: $Calcite_Red_a250;
 
 // our containing block element
 @mixin toggle-switch {
@@ -48,8 +48,8 @@ $handle-destructive-checked-border-color: $Calcite_Red_a200;
 
 // spacing for label
 @mixin toggle-switch-label {
-  width: calc((100% - 3rem) - .5rem);
-  padding: 0 .1rem;
+  width: calc((100% - 3em) - .5em);
+  padding: 0 .1em;
   vertical-align: top;
 }
 
@@ -60,20 +60,11 @@ $handle-destructive-checked-border-color: $Calcite_Red_a200;
   vertical-align: top;
   width: $switch-width;
   height: $switch-height;
-  top: .05rem;
+  top: .05em;
   background-color: $switch-bg;
   border-radius: 30px;
   border: 1px solid $switch-border-color;
   @include transition(all 0.25s ease);
-  &.toggle-switch-inline {
-    margin-right: .5rem;
-  }
-  @if ($include-right-to-left) {
-    html[dir="rtl"] &.toggle-switch-inline {
-      margin-left: .5rem;
-      margin-right: 0;
-    }
-  }
   // handle
   &:after {
     position: absolute;
@@ -85,7 +76,7 @@ $handle-destructive-checked-border-color: $Calcite_Red_a200;
     left: $handle-edge-distance;
     background-color: $handle-bg;
     border-radius: 30px;
-    border: 3px solid $handle-border-color;
+    border: 2px solid $handle-border-color;
     box-shadow: $handle-shadow;
     @include transition(all 0.25s ease);
     @if ($include-right-to-left) {
@@ -96,11 +87,11 @@ $handle-destructive-checked-border-color: $Calcite_Red_a200;
     }
   }
   // alignment fixes for edge
-  @supports (-ms-ime-align: auto) { & { top: .3rem; }}
+  @supports (-ms-ime-align: auto) { & { top: .4em; }}
   // alignment fixes for ff
-  @supports (-moz-appearance:none) { & { top: .1rem; }}
+  @supports (-moz-appearance:none) { & { top: .1em; }}
   // alignment fixes for ios
-  @supports (-webkit-overflow-scrolling: touch) { & { top: .15rem; }}
+  @supports (-webkit-overflow-scrolling: touch) { & { top: .15em; }}
 }
 
 @mixin toggle-switch-input {


### PR DESCRIPTION
Please give this a look over... Basically just setting a string that matches theme title in localstorage and retrieving it on load / changing it on click. The fade animations are stored in an always present css file to alleviate flash in as much as possible.

Of course some weird browser issues exist... Firefox is the offender here requiring us to set disabled via JS on load as it doesn't interpret the "disabled" in the markup itself. It seems to handle switching themes the worst since the disabled value is set after load. Tested and working down to IE10.

Occasionally, there remains a short flash as the stylesheet is swapped, so all ears if there's a better solution. The content itself is actually styled but the switch from #fff to #000 is abrupt.

Open to moving it somewhere less prominent / changing copy as well... 

Kind of tangential but related to dark theme, but the #fff -> #000 is tough. Many folks use #fff as a bg, but making that true black means dark mode is pretty tough on the eyes. Another battle...

- Updates to switch component styles to match comps as well as slider tweaks to match the switch.
- Styleguide modifier overflow fix