### PR TITLE
Wrap long code strings by default

### DIFF
--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -70,7 +70,7 @@
     border: 1px solid $lightest-gray;
     color: $darkest-gray;
     background-color: $off-white;
-    white-space: pre;
+    white-space: initial;
     font-size: 0.85em;
     line-height: 1.4rem;
   }
@@ -86,6 +86,7 @@
       display: block;
       overflow: auto;
       word-wrap: normal;
+      white-space: pre;
       font-size: 0.85em;
       position: relative;
     }


### PR DESCRIPTION
Fix for https://github.com/Esri/calcite-web/issues/888 