### PR TITLE
#742 - fix rounding error by making column max more even

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased][unreleased]
+
+### Fixes
+- Fix rounding error on certain column widths (#742)
+
 ## [1.0.0-rc.9][1.0.0-rc.9]
 
 ### Fixes

--- a/lib/sass/calcite-web/base/_config.scss
+++ b/lib/sass/calcite-web/base/_config.scss
@@ -31,7 +31,7 @@ $large:                    1450px                      !default;
 //  ↳ grid → _configuration.md
 $prefix:                   ""                          !default;
 
-$vw-ratio:                 0.95;
+$vw-ratio:                 0.96;
 $container-width:          1450px                      !default;
 $max-width:                $vw-ratio * 100vw           !default;
 $column-gutter:            1rem                        !default;


### PR DESCRIPTION
Setting the `$vw-ratio` slightly higher solved this problem. Here is some background information to this rather strange variable and why this fixes the problem:

### What is vw-ratio?

It seems like if you have a grid that's based on vw units, you could use `100vw` as the your width, and subdivide that by however many columns and be done with it, right? _Wrong_. On certain browsers, the width of the scroll bar is _part_ of the `100vw`, so if you have column widths that add up to 100, and the user has scroll bars turned on, the second column breaks to the next line. 

Because of this, we added the `$vw-ratio` variable that sets the max container size at slightly less than `100vw`. 

### Why does this fix the bug?

Previously this variable was set to `.95`, which mean that every column was `95 / 24`, or `3.9583333333`. By moving to `.96` this becomes `4`. And the rounding errors all go away. 