### PR TITLE
v1.0.0 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Fix rounding error on certain column widths (#742)
+- Pre and post were broken for large screen size
 
 ## [1.0.0-rc.9][1.0.0-rc.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 - Fix rounding error on certain column widths (#742)
 - Fix `pre` and `post missing on large screen size
 - Fix `pre` on first nested column at largest size (#806)
+- Use unitless line-height (#847)
 
 ### Breaking
-- Font size changed to `16px` (was 17px)
+- Font size changed from `17px` to `16px` (#889)
 
 ## [1.0.0-rc.9][1.0.0-rc.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Fixes
 - Fix rounding error on certain column widths (#742)
-- Pre and post were broken for large screen size
+- Fix `pre` and `post missing on large screen size
+- Fix `pre` on first nested column at largest size (#806)
 
 ## [1.0.0-rc.9][1.0.0-rc.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix `pre` and `post missing on large screen size
 - Fix `pre` on first nested column at largest size (#806)
 
+### Breaking
+- Font size changed to `16px` (was 17px)
+
 ## [1.0.0-rc.9][1.0.0-rc.9]
 
 ### Fixes

--- a/docs/source/assets/css/_doc.scss
+++ b/docs/source/assets/css/_doc.scss
@@ -11,7 +11,6 @@ $include-calcite-icons: false;
 // Use this to test dark theme
 // @import "calcite-web-dark";
 
-@import "calcite-web";
 @import "github";
 
 // Splashy banner stuff

--- a/docs/source/assets/css/all.scss
+++ b/docs/source/assets/css/all.scss
@@ -1,6 +1,2 @@
-$include-content-family: true;
-$include-secondary-family: true;
-$include-calcite-icons: false;
-
 @import "calcite-web";
 @import "doc";

--- a/docs/source/assets/css/dark.scss
+++ b/docs/source/assets/css/dark.scss
@@ -1,6 +1,2 @@
-$include-content-family: true;
-$include-secondary-family: true;
-$include-calcite-icons: false;
-
 @import "calcite-web-dark";
 @import "doc";

--- a/docs/source/assets/css/imports.scss
+++ b/docs/source/assets/css/imports.scss
@@ -1,2 +1,2 @@
-$generate-css: false;
-@import "calcite-web";
+@import "calcite-web/imports";
+

--- a/docs/source/examples/grid/index.html
+++ b/docs/source/examples/grid/index.html
@@ -91,8 +91,8 @@ active: grid
         <div class="column-5 tablet-column-4 phone-first-column">
           <span class="tablet-hide">.column-5</span>
           <span class="tablet-show">.tablet-column-4</span>
-          <div class="column-2 tablet-column-4 phone-first-column">
-            <span class="tablet-hide">2</span>
+          <div class="column-1 pre-1 tablet-column-4 phone-first-column">
+            <span class="tablet-hide">1</span>
             <span class="tablet-show">.tablet-column-4</span>
           </div>
           <div class="column-3 tablet-column-4 tablet-first-column phone-first-column">

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -115,13 +115,13 @@
               <a href="{{relativePath}}/quick-reference" class="{% if isQuickRef %}is-active {% endif %}top-nav-link">Quick Reference</a>
             </nav>
             <nav class="class-top-nav-list right" role="navigation" aria-labelledby="usernav">
-              <a class="top-nav-link padding-leader-0 padding-trailer-0 trailer-0 margin-right-1">
+              <span class="margin-right-1 inline-block">
                 <label class="toggle-switch trailer-0 docs-toggle-spacer">
                   <input type="checkbox" class="toggle-switch-input docs-theme-toggle">
                   <span class="toggle-switch-track margin-right-half"></span>
                   <span class="toggle-switch-labe">Dark Theme</span>
                 </label>
-              </a>
+              </span>
               <button class="search-top-nav link-dark-gray js-search-toggle" href="#" aria-label="Search">
                 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="svg-icon js-search-icon">
                   <path d="M31.607 27.838l-6.133-6.137a1.336 1.336 0 0 0-1.887 0l-.035.035-2.533-2.533-.014.014c3.652-4.556 3.422-11.195-.803-15.42-4.529-4.527-11.875-4.531-16.404 0-4.531 4.531-4.529 11.875 0 16.406 4.205 4.204 10.811 4.455 15.365.848l.004.003-.033.033 2.541 2.54a1.33 1.33 0 0 0 .025 1.848l6.135 6.133a1.33 1.33 0 0 0 1.887 0l1.885-1.883a1.332 1.332 0 0 0 0-1.887zM17.811 17.809a8.213 8.213 0 0 1-11.619 0 8.217 8.217 0 0 1 0-11.622 8.219 8.219 0 0 1 11.619.004 8.216 8.216 0 0 1 0 11.618z"/>

--- a/lib/sass/calcite-web/base/_config.scss
+++ b/lib/sass/calcite-web/base/_config.scss
@@ -59,4 +59,5 @@ $small-column-count:       6                           !default;
 // Rhythm
 $horizontal-range:         4                           !default;
 $vertical-range:           6                           !default;
-$baseline:                 1.55rem                     !default;
+$baseline-ratio:           1.5                         !default;
+$baseline:                 $baseline-ratio * 1rem      !default;

--- a/lib/sass/calcite-web/components/_button.scss
+++ b/lib/sass/calcite-web/components/_button.scss
@@ -7,7 +7,7 @@
 @mixin btn() {
   position: relative;
   display: inline-block;
-  padding: $baseline/5 0.9rem;
+  padding: $baseline/4 1rem;
   width: auto;
   color: $white;
   border: 1px solid $blue;
@@ -89,12 +89,12 @@
 
 @mixin btn-small() {
   @include font-size(-2);
-  padding: $baseline/5 * 0.75 0.9rem * 0.75;
+  padding: $baseline/4 * 0.75 1rem * 0.75;
 }
 
 @mixin btn-large() {
   @include font-size(0);
-  padding: 0.5rem 1rem 0.5rem;
+  padding: 0.5rem 1rem;
 }
 
 @mixin btn-fill() {

--- a/lib/sass/calcite-web/grid/_pre-post.scss
+++ b/lib/sass/calcite-web/grid/_pre-post.scss
@@ -60,7 +60,7 @@
     @media screen and (min-width: $magic-number + 3) {
       @for $n from 0 through $large-column-count {
         .pre-#{$n}  {
-          html:not([dir="rtl"]) {
+          html:not([dir="rtl"]) & {
             margin-left: ($n / $large-column-count) * $container-width - 1;
           }
           html[dir="rtl"] & {
@@ -68,7 +68,7 @@
           }
         }
         .post-#{$n} {
-          html:not([dir="rtl"]) {
+          html:not([dir="rtl"]) & {
             margin-right: ($n / $large-column-count) * $container-width - 1;
           }
           html[dir="rtl"] & {

--- a/lib/sass/calcite-web/grid/_pre-post.scss
+++ b/lib/sass/calcite-web/grid/_pre-post.scss
@@ -60,28 +60,6 @@
     // Fixed Pre and Post
     @media screen and (min-width: $magic-number + 3) {
       @for $n from 0 through $large-column-count {
-        .pre-#{$n}  {
-          html:not([dir="rtl"]) & {
-            margin-left: ($n / $large-column-count) * $container-width - 1;
-          }
-          html[dir="rtl"] & {
-            margin-right: ($n / $large-column-count) * $container-width - 1;
-          }
-        }
-        .post-#{$n} {
-          html:not([dir="rtl"]) & {
-            margin-right: ($n / $large-column-count) * $container-width - 1;
-          }
-          html[dir="rtl"] & {
-            margin-left: ($n / $large-column-count) * $container-width - 1;
-          }
-        }
-      }
-    }
-
-    // Fixed Pre and Post
-    @media screen and (min-width: $magic-number + 3) {
-      @for $n from 0 through $large-column-count {
         $fixed-pre: ($n / $large-column-count) * $container-width - 1;
         $clear: $column-gutter / 2;
         .pre-#{$n} {

--- a/lib/sass/calcite-web/grid/_pre-post.scss
+++ b/lib/sass/calcite-web/grid/_pre-post.scss
@@ -8,7 +8,6 @@
   $remainder: 1 - $vw-ratio;
   $margin-overflow: $container-width * $remainder;
   $magic-number: $container-width + $margin-overflow;
-
   @if $fold-grid == true {
     // Normal Columns
     @media screen and (min-width: $medium) and (max-width: $magic-number + 2) {
@@ -22,9 +21,11 @@
         .post-#{$n} {
           @include post($n, $default-column-count);
         }
+        [class*="#{$prefix}column-"] [class*="#{$prefix}column-"].pre-#{$n}:first-of-type  {
+          @include pre-calc($n, $default-column-count);
+        }
       }
     }
-
 
     // Medium Columns
     @media screen and (max-width: $medium - 1) {
@@ -73,6 +74,47 @@
           }
           html[dir="rtl"] & {
             margin-left: ($n / $large-column-count) * $container-width - 1;
+          }
+        }
+      }
+    }
+
+    // Fixed Pre and Post
+    @media screen and (min-width: $magic-number + 3) {
+      @for $n from 0 through $large-column-count {
+        $fixed-pre: ($n / $large-column-count) * $container-width - 1;
+        $clear: $column-gutter / 2;
+        .pre-#{$n} {
+          html:not([dir="rtl"]) & {
+            margin-left: $fixed-pre;
+          }
+          html[dir="rtl"] & {
+            margin-right: $fixed-pre;
+          }
+        }
+        .post-#{$n} {
+          html:not([dir="rtl"]) & {
+            margin-right: $fixed-pre;
+          }
+          html[dir="rtl"] & {
+            margin-left: $fixed-pre;
+          }
+        }
+        [class*="#{$prefix}column-"] [class*="#{$prefix}column-"].pre-#{$n}:first-of-type  {
+          html:not([dir="rtl"]) & {
+            margin-left: calc(#{$fixed-pre} - #{$clear});
+
+          }
+          html[dir="rtl"] & {
+            margin-right: calc(#{$fixed-pre} - #{$clear});
+          }
+        }
+        [class*="#{$prefix}column-"] [class*="#{$prefix}column-"].post-#{$n}:last-of-type {
+          html:not([dir="rtl"]) & {
+            margin-right: calc(#{$fixed-pre} - #{$clear});
+          }
+          html[dir="rtl"] & {
+            margin-left: calc(#{$fixed-pre} - #{$clear});
           }
         }
       }

--- a/lib/sass/calcite-web/imports.scss
+++ b/lib/sass/calcite-web/imports.scss
@@ -1,2 +1,74 @@
-$generate-css: false;
+// Language Helpers
+$include-right-to-left:          false;
+
+// Grid Output
+$include-reset:                  false;
+$include-utils:                  false;
+
+$include-grid:                   false;
+  $fold-grid:                    false;
+  $block-grid:                   false;
+
+// Grid Utilities Output
+$include-leader-trailer:         false;
+$include-gutter:                 false;
+$include-left-right:             false;
+$include-show-hide:              false;
+$include-sticky:                 false;
+
+// Type Output
+$include-type:                   false;
+  $include-primary-family:       false;
+  $include-code-family:          false;
+  $include-i18n:                 false;
+  $include-type-defaults:        false;
+  $include-type-helpers:         false;
+
+// Icons
+$include-icons:                  false;
+  $include-calcite-icons:        false;
+  $include-social-icons:         false;
+  $include-icon-font:            false;
+  $include-svg-icon:             false;
+
+// Components
+$include-alerts:                 false;
+$include-badges:                 false;
+$include-labels:                 false;
+$include-tables:                 false;
+$include-panel:                  false;
+$include-button:                 false;
+$include-dropdowns:              false;
+$include-breadcrumbs:            false;
+$include-tooltip:                false;
+$include-forms:                  false;
+$include-input-groups:           false;
+$include-loader:                 false;
+$include-skip-to-content:        false;
+$include-logo:                   false;
+$include-card:                   false;
+$include-animation:              false;
+$include-sliders:                false;
+$include-switches:               false;
+
+// Patterns
+$include-footer:                 false;
+$include-sticky-footer:          false;
+$include-pagination:             false;
+$include-side-nav:               false;
+$include-sub-nav:                false;
+$include-third-nav:              false;
+$include-top-nav:                false;
+$include-user-nav:               false;
+$include-app-switcher:           false;
+
+// Javascript
+$include-tabs:                   false;
+$include-modal:                  false;
+$include-search:                 false;
+$include-accordion:              false;
+$include-drawers:                false;
+$include-sticky:                 false;
+$include-filter-dropdown:        false;
+
 @import '../calcite-web';

--- a/lib/sass/calcite-web/type/_scale.scss
+++ b/lib/sass/calcite-web/type/_scale.scss
@@ -118,16 +118,19 @@
 @mixin font-size($n) {
   font-size: modular-scale($n);
   @if $n > 7 {
-    line-height: 2.5*$baseline;
+    line-height: $baseline-ratio*.85;
   }
-  @else if $n <= 7 and $n > 4 {
-    line-height: 2*$baseline;
+  @else if $n <= 7 and $n > 5 {
+   line-height: $baseline-ratio*.875;
   }
-  @else if $n <= 4 and $n > 2 {
-    line-height: 1.5*$baseline;
+  @else if $n <= 5 and $n > 3 {
+    line-height: $baseline-ratio*.9;
+  }
+  @else if $n <= 3 and $n > 2 {
+    line-height: $baseline-ratio*.925;
   }
   @else if $n <= 2 {
-    line-height: $baseline;
+    line-height: $baseline-ratio;
   }
   @if $n > 0 {
     @media screen and (max-width: $medium - 1) {
@@ -135,12 +138,6 @@
     }
     @media screen and (max-width: $small - 1) {
       font-size: small-modular-scale($n);
-      @if $n > 7 {
-        line-height: 2*$baseline;
-      }
-      @else if $n <= 7 and $n > 4 {
-        line-height: 1.5*$baseline;
-      }
     }
   }
 }

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -5,7 +5,7 @@
 @if $include-type == true and $include-type-defaults == true {
 
   html {
-    font-size: 17px;
+    font-size: 16px;
   }
 
   body {

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -10,10 +10,9 @@
 
   body {
     @include avenir-regular();
-    @include font-size(0);
     @include tracking($avenir-tracking);
     font-family: $avenir-family;
-    line-height: $baseline;
+    line-height: $baseline-ratio;
     color: $type-color;
     background-color: $white;
 
@@ -50,7 +49,7 @@
   h5,
   h6 {
     font-weight: 400;
-    margin: 0 0 $baseline 0;
+    margin: 0 0 $baseline*.5 0;
   }
 
   h1 {@include font-size(5);}


### PR DESCRIPTION
- Change type size from 17px to 16px (#889)
- All line heights are not unit-less, so they inherit/cascade better (#847)
- base line-height is now 1.5 instead of 1.55, this keeps type spacing at whole pixels most of the time (#826)
- Fixed a couple bugs with pre/post as well
- Explicitly set all vars to `false` in imports to reduce the chance of multiple inclusions of built CSS when importing mixins