### PR TITLE
remove the '.'s from /examples/grid/

### DIFF
--- a/docs/source/examples/grid/index.html
+++ b/docs/source/examples/grid/index.html
@@ -24,110 +24,110 @@ active: grid
 
   <div class="grid-example trailer-2 leader-1">
     <div class="column-1"><span>1</span></div>
-    <div class="column-23"><span>.column-23</span></div>
+    <div class="column-23"><span>column-23</span></div>
     <div class="column-2"><span>2</span></div>
-    <div class="column-22"><span>.column-22</span></div>
+    <div class="column-22"><span>column-22</span></div>
     <div class="column-3"><span>3</span></div>
-    <div class="column-21"><span>.column-21</span></div>
+    <div class="column-21"><span>column-21</span></div>
     <div class="column-4"><span>4</span></div>
-    <div class="column-20"><span>.column-20</span></div>
-    <div class="column-5"><span>.column-5</span></div>
-    <div class="column-19"><span>.column-19</span></div>
-    <div class="column-6"><span>.column-6</span></div>
-    <div class="column-18"><span>.column-18</span></div>
-    <div class="column-7"><span>.column-7</span></div>
-    <div class="column-17"><span>.column-17</span></div>
-    <div class="column-8"><span>.column-8</span></div>
-    <div class="column-16"><span>.column-16</span></div>
-    <div class="column-9"><span>.column-9</span></div>
-    <div class="column-15"><span>.column-15</span></div>
-    <div class="column-10"><span>.column-10</span></div>
-    <div class="column-14"><span>.column-14</span></div>
-    <div class="column-11"><span>.column-11</span></div>
-    <div class="column-13"><span>.column-13</span></div>
-    <div class="column-12"><span>.column-12</span></div>
-    <div class="column-12"><span>.column-12</span></div>
+    <div class="column-20"><span>column-20</span></div>
+    <div class="column-5"><span>column-5</span></div>
+    <div class="column-19"><span>column-19</span></div>
+    <div class="column-6"><span>column-6</span></div>
+    <div class="column-18"><span>column-18</span></div>
+    <div class="column-7"><span>column-7</span></div>
+    <div class="column-17"><span>column-17</span></div>
+    <div class="column-8"><span>column-8</span></div>
+    <div class="column-16"><span>column-16</span></div>
+    <div class="column-9"><span>column-9</span></div>
+    <div class="column-15"><span>column-15</span></div>
+    <div class="column-10"><span>column-10</span></div>
+    <div class="column-14"><span>column-14</span></div>
+    <div class="column-11"><span>column-11</span></div>
+    <div class="column-13"><span>column-13</span></div>
+    <div class="column-12"><span>column-12</span></div>
+    <div class="column-12"><span>column-12</span></div>
   </div>
 
   <h2 id="center-column" class="column-24 leader-3">Center Column</h2>
 
   <div class="grid-example">
     <div class="column-24 trailer-3">
-     <div class="column-10 center-column"><span>.column-8.center-column</span></div>
+     <div class="column-10 center-column"><span>column-8 center-column</span></div>
    </div>
 
   <h2 id="nested-columns" class="padding-leader-2 column-24">Nested Columns</h2>
 
   <div class="grid-example trailer-2 nested-demo">
     <div class="column-18 tablet-column-8">
-      <span class="tablet-hide">.column-18</span>
-      <span class="tablet-show">.tablet-column-8</span>
+      <span class="tablet-hide">column-18</span>
+      <span class="tablet-show">tablet-column-8</span>
       <div class="column-3 pre-1 tablet-column-4">
-        <span class="tablet-hide">.column-3</span>
-        <span class="tablet-show">.tablet-column-4</span>
+        <span class="tablet-hide">column-3</span>
+        <span class="tablet-show">tablet-column-4</span>
         <div class="column-1 tablet-column-4">
           <span class="tablet-hide">1</span>
-          <span class="tablet-show">.tablet-column-4</span>
+          <span class="tablet-show">tablet-column-4</span>
         </div>
         <div class="column-1 tablet-column-4 tablet-first-column">
           <span class="tablet-hide">1</span>
-          <span class="tablet-show">.tablet-column-4</span>
+          <span class="tablet-show">tablet-column-4</span>
         </div>
         <div class="column-1 tablet-column-4 tablet-first-column">
           <span class="tablet-hide">1</span>
-          <span class="tablet-show">.tablet-column-4</span>
+          <span class="tablet-show">tablet-column-4</span>
         </div>
       </div>
       <div class="column-2 tablet-column-4 tablet-last-column phone-first-column">
         <span class="tablet-hide">2</span>
-        <span class="tablet-show">.tablet-column-4</span>
+        <span class="tablet-show">tablet-column-4</span>
       </div>
       <div class="column-10 tablet-column-8 tablet-first-column">
-        <span class="tablet-hide">10</span><span class="tablet-show">.tablet-column-8</span>
+        <span class="tablet-hide">10</span><span class="tablet-show">tablet-column-8</span>
         <div class="column-5 tablet-column-4">
-          <span class="tablet-hide">.column-5</span>
-          <span class="tablet-show">.tablet-column-4</span>
+          <span class="tablet-hide">column-5</span>
+          <span class="tablet-show">tablet-column-4</span>
         </div>
         <div class="column-5 tablet-column-4 phone-first-column">
-          <span class="tablet-hide">.column-5</span>
-          <span class="tablet-show">.tablet-column-4</span>
+          <span class="tablet-hide">column-5</span>
+          <span class="tablet-show">tablet-column-4</span>
           <div class="column-1 pre-1 tablet-column-4 phone-first-column">
             <span class="tablet-hide">1</span>
-            <span class="tablet-show">.tablet-column-4</span>
+            <span class="tablet-show">tablet-column-4</span>
           </div>
           <div class="column-3 tablet-column-4 tablet-first-column phone-first-column">
-            <span class="tablet-hide">.column-3</span>
-            <span class="tablet-show">.tablet-column-4</span>
+            <span class="tablet-hide">column-3</span>
+            <span class="tablet-show">tablet-column-4</span>
           </div>
         </div>
       </div>
       <div class="column-1 tablet-column-4 tablet-first-column">
         <span class="tablet-hide">1</span>
-        <span class="tablet-show">.tablet-column-4</span>
+        <span class="tablet-show">tablet-column-4</span>
       </div>
       <div class="column-1 tablet-column-5 tablet-first-column">
         <span class="tablet-hide">1</span>
-        <span class="tablet-show">.tablet-column-5</span>
+        <span class="tablet-show">tablet-column-5</span>
       </div>
     </div>
     <div class="column-6 tablet-column-4">
-      <span class="tablet-hide">.column-6</span>
-      <span class="tablet-show">.tablet-column-4</span>
+      <span class="tablet-hide">column-6</span>
+      <span class="tablet-show">tablet-column-4</span>
       <div class="column-6 tablet-column-4">
-        <span class="tablet-hide">.column-6</span>
-        <span class="tablet-show">.tablet-column-4</span>
+        <span class="tablet-hide">column-6</span>
+        <span class="tablet-show">tablet-column-4</span>
         <div class="column-4 tablet-column-2">
-          <span class="tablet-hide">.column-4</span>
-          <span class="tablet-show">.tablet-column-2</span>
+          <span class="tablet-hide">column-4</span>
+          <span class="tablet-show">tablet-column-2</span>
         </div>
         <div class="column-2 tablet-column-2">
           <span class="tablet-hide">2</span>
-          <span class="tablet-show">.tablet-column-2</span>
+          <span class="tablet-show">tablet-column-2</span>
         </div>
       </div>
       <div class="column-4 tablet-column-4 column-first tablet-first-column">
-        <span class="tablet-hide first-column">.column-4</span>
-        <span class="tablet-show">.tablet-column-4</span>
+        <span class="tablet-hide first-column">column-4</span>
+        <span class="tablet-show">tablet-column-4</span>
       </div>
     </div>
   </div>
@@ -169,12 +169,12 @@ active: grid
       <span>col</span>
     </div>
     <div class="column-2 pre-21 tablet-pre-9 phone-pre-3">
-      <span>.pre-21</span>
+      <span>pre-21</span>
     </div>
   </div>
   <div class="grid-example trailer-2 leader-1">
     <div class="column-2 post-21 tablet-post-9 phone-post-3">
-      <span>.post-21</span>
+      <span>post-21</span>
     </div>
     <div class="column-1">
       <span>col</span>
@@ -184,34 +184,34 @@ active: grid
   <h2 class="padding-leader-2 column-24" id="rows">Rows</h2>
 
   <div class="grid-example">
-    <div class="column-2"><span>.column-2 With a lot of content, so it pushes down.</span></div>
-    <div class="column-22"><span>.column-22</span></div>
-    <div class="column-4"><span>.column-4</span></div>
-    <div class="column-4"><span>.column-4</span></div>
-    <div class="column-4"><span>.column-4</span></div>
+    <div class="column-2"><span>column-2 With a lot of content, so it pushes down.</span></div>
+    <div class="column-22"><span>column-22</span></div>
+    <div class="column-4"><span>column-4</span></div>
+    <div class="column-4"><span>column-4</span></div>
+    <div class="column-4"><span>column-4</span></div>
   </div>
   <div class="grid-example">
     <div class="column-24">
-      <div class="column-2"><span>.column-2 With a lot of content, so it pushes down.</span></div>
-      <div class="column-22 tablet-first-column"><span>.column-22</span></div>
+      <div class="column-2"><span>column-2 With a lot of content, so it pushes down.</span></div>
+      <div class="column-22 tablet-first-column"><span>column-22</span></div>
     </div>
-    <div class="column-4"><span>.column-4</span></div>
-    <div class="column-4"><span>.column-4</span></div>
-    <div class="column-4"><span>.column-4</span></div>
+    <div class="column-4"><span>column-4</span></div>
+    <div class="column-4"><span>column-4</span></div>
+    <div class="column-4"><span>column-4</span></div>
   </div>
 
   <h2 id="block-groups" class="padding-leader-2 column-24">Block Groups</h2>
 
   <div class="grid-example trailer-2 leader-1 column-24">
     <div class="block-group block-group-4-up">
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
-      <div class="block"><span>.block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
+      <div class="block"><span>block-group-4-up</span></div>
     </div>
   </div>
 
@@ -219,14 +219,14 @@ active: grid
 
   <div class="grid-example trailer-2 leader-1 column-24">
     <div class="block-group block-group-4-up tablet-block-group-2-up phone-block-group-1-up">
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
-      <div class="block"><span>.block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
+      <div class="block"><span>block</span></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* <kbd>.column-24</kbd> > <kbd>column-24</kbd>
* <kbd>.column-8.center-column</kbd> > <kbd>column-8 center-column</kbd>

for consistency with http://esri.github.io/calcite-web/documentation/grid/#columns