### PR TITLE
make grid container default size 1440px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Breaking
 - Font size changed from `17px` to `16px` (#889)
+- Grid container size default is now 1440px instead of 1450px (#826)
 
 ## [1.0.0-rc.9][1.0.0-rc.9]
 

--- a/docs/source/examples/grid/index.html
+++ b/docs/source/examples/grid/index.html
@@ -16,7 +16,7 @@ active: grid
     <div class="column-24 trailer-5">
      <div class="column-1"><span>1</span></div>
      <div class="column-4 pre-4 post-6"><span>4 pre-4 post-6</span></div>
-     <div class="column-1"><span>1</span></div>
+     <div class="column-9"><span>column-9</span></div>
    </div>
   </div>
 

--- a/lib/sass/calcite-web/base/_config.scss
+++ b/lib/sass/calcite-web/base/_config.scss
@@ -22,7 +22,7 @@ $link-hover:               $dark-blue                  !default;
 //  ↳ sass → _breakpoints.md
 $small:                    480px                       !default;
 $medium:                   860px                       !default;
-$large:                    1450px                      !default;
+$large:                    1440px                      !default;
 
 // ┌────────────────────┐
 // │ Grid Configuration │
@@ -32,7 +32,7 @@ $large:                    1450px                      !default;
 $prefix:                   ""                          !default;
 
 $vw-ratio:                 0.96;
-$container-width:          1450px                      !default;
+$container-width:          1440px                      !default;
 $max-width:                $vw-ratio * 100vw           !default;
 $column-gutter:            1rem                        !default;
 

--- a/lib/sass/calcite-web/grid/_pre-post.scss
+++ b/lib/sass/calcite-web/grid/_pre-post.scss
@@ -5,12 +5,11 @@
 //  ↳ grid → _pre-and-post.md
 
 @mixin responsive-pre-post(){
-  $remainder: 1 - $vw-ratio;
-  $margin-overflow: $container-width * $remainder;
-  $magic-number: $container-width + $margin-overflow;
+  // point where container width is exactly $vw-ratio (.96) of screen width
+  $container-plus-buffer: $container-width / $vw-ratio;
   @if $fold-grid == true {
     // Normal Columns
-    @media screen and (min-width: $medium) and (max-width: $magic-number + 2) {
+    @media screen and (min-width: $medium) and (max-width: $container-plus-buffer) {
       @for $n from 0 through $default-column-count {
         .pre-#{$n} {
           @include pre($n, $default-column-count);
@@ -58,7 +57,7 @@
     }
 
     // Fixed Pre and Post
-    @media screen and (min-width: $magic-number + 3) {
+    @media screen and (min-width: $container-plus-buffer + 1) {
       @for $n from 0 through $large-column-count {
         $fixed-pre: ($n / $large-column-count) * $container-width - 1;
         $clear: $column-gutter / 2;


### PR DESCRIPTION
This means that each columns width once we hit the upper limit is now an even pixel value. This will help with rounding errors from fractional lengths.

#826 