### PR TITLE
Propose to slightly reword Button Links doc section and add an example

### DIFF
--- a/docs/source/documentation/components/_buttons.md
+++ b/docs/source/documentation/components/_buttons.md
@@ -8,6 +8,9 @@ Buttons are created by adding a class of `btn` to either a `<button>` or `<a>` e
 
 #### Button Links
 
-Sometimes, the proper semantic element is a button, but you would rather the element look more like a link. In these instances, Calcite Web provides an additional class `btn-link` which styles a button element as if it were a simple anchor:
+Sometimes, the proper semantic element is a button, but you would rather the element look more like a link. In these instances, Calcite Web provides an alternate class `btn-link` which styles a button element as if it were a simple anchor:
 
 <button class="btn-link">This is a button</button>
+```html
+<button class="btn-link">This is a button</button>
+```


### PR DESCRIPTION
When I tried to use btn-link, I added it as a modifier because of the wording "provides an additional class". It wasn't until I opened up the source that I saw that "btn-link" is an alternate to "btn".  Perhaps changing "additional" and adding an example will help.