### PR TITLE
Add doc example styling option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ Adding a component to Calcite Web requires a few steps:
             - tooltip-left
             - tooltip-right
             - tooltip-top
+          doc_classes:
+            - example-modifier-class # Accepts a list of class names for styling documentation examples
 ```
 4. Run a local server (`npm start`) and develop your component
 5. Add an entry in the `CHANGELOG` describing your new component.

--- a/docs/source/assets/css/_doc.scss
+++ b/docs/source/assets/css/_doc.scss
@@ -39,6 +39,10 @@ $include-calcite-icons: false;
   @include clearfix();
   background: $white;
   overflow-x: scroll;
+  &.styleguide-modifiers-overflow-visible {
+    overflow-y: visible;
+    overflow-x: visible;
+  }
   .styleguide-modifier-example {
     min-height: 2rem;
     padding: .5em;

--- a/docs/source/layouts/_doc.html
+++ b/docs/source/layouts/_doc.html
@@ -148,7 +148,7 @@
         {% endif %}
 
         {% if page.modifiers or page.modifiers == false %}
-        <div class="styleguide-modifiers">
+        <div class="styleguide-modifiers {% if page.doc_classes %}{% for doc_class in page.doc_classes %}{{ doc_class }} {% endfor %}{% endif %}">
           <div class="styleguide-modifier-example">
             {% include 'documentation/' + data.table_of_contents[section].base + '/sample-code/_' + page.link %}
             {% if page.classes %} <code class="modifier-name">.{{ page.classes }}</code>{% endif %}
@@ -163,7 +163,7 @@
 
         {% if page.modifiers != false %}
         <h4 class="leader-0 text-darkest-gray" tabindex="0">Modifiers</h4>
-        <div class="styleguide-modifiers trailer-1">
+        <div class="styleguide-modifiers trailer-1 {% if page.doc_classes %}{% for doc_class in page.doc_classes %}{{ doc_class }} {% endfor %}{% endif %}">
           {% for modifier in page.modifiers %}
           <div class="styleguide-modifier-example">
             {% include 'documentation/' + data.table_of_contents[section].base + '/sample-code/_' + page.link %}

--- a/docs/source/table_of_contents.yml
+++ b/docs/source/table_of_contents.yml
@@ -410,6 +410,8 @@ components:
             - dropdown
           modifiers:
             - dropdown-right
+          doc_classes:
+            - styleguide-modifiers-overflow-visible
         - title: 'Loader'
           link: loader
           status: 'complete'
@@ -641,6 +643,8 @@ patterns:
         - title: 'Filter Dropdown'
           link: 'filter-dropdown'
           modifiers: false
+          doc_classes:
+            - styleguide-modifiers-overflow-visible
 sass:
   title: 'Sass'
   base: sass


### PR DESCRIPTION
Here's an attempt to find some middle ground... This is really only a docs issue since we have to constrain what would be full-width items into their example containers. Unfortunately that means we can't ALSO have vertical overflow (https://www.brunildo.org/test/Overflowxy2.html).

I added a modifier class we can apply in the table of contents to allow overflow-y on a per-component basis. It works for the dropdowns (https://github.com/Esri/calcite-web/issues/944) but it has the potential to cause overflow-x problems if added to other components, so it's not totally ideal. 

I don't think we want to get in the habit of it, but it's possible to pass other classes in the table of contents for additional styling as well.