### PR TITLE
fix broken link in code comment

### DIFF
--- a/lib/js/calcite-web.js
+++ b/lib/js/calcite-web.js
@@ -4,7 +4,7 @@
 // This file imports all the named ES6 exports
 // and attaches them to the same object (calcite).
 // For more information about using the bundle vs. using individual
-// ES6 modules, see esri.github.io/documentation/javascript/#importing
+// ES6 modules, see esri.github.io/calcite-web/documentation/javascript/#importing
 import {
   version,
   click,


### PR DESCRIPTION
greetings!

_**not** a dealbreaker_, but i noticed that the version number in the copyright header for all [`v1.0.1`](https://github.com/Esri/calcite-web/blob/master/dist/js/calcite-web.min.js) files are out of sync with the actual release.

> /*!
> * Calcite Web - Calcite Design Components in CSS, JS and HTML
> * @version v1.0.0
> * @license Apache-2.0

digging in a little, everything looks okay with your [rollup.config](https://github.com/Esri/calcite-web/blob/6c5609a9729e85c59e3e673eeec68e072425d967/lib/js/rollup.config.js#L7) and since `v1.0.0` doesn't have the same problem, maybe it was just the order of operations specifically when you [tagged](https://github.com/Esri/calcite-web/blob/master/CONTRIBUTING.md#bumping-the-version) the first patch?

either way, congrats on exiting the beta!