### PR TITLE
Modals without duplicate event listeners

### DIFF
--- a/lib/js/helpers/event.js
+++ b/lib/js/helpers/event.js
@@ -4,7 +4,8 @@
 
 var boundEvents = {
   dropdowns: [],
-  accordions: []
+  accordions: [],
+  modals: []
 };
 
 export { boundEvents };

--- a/lib/js/patterns/modal.js
+++ b/lib/js/patterns/modal.js
@@ -74,7 +74,7 @@ function modal () {
     if (!node) {
       toggles.forEach(function (toggle) {
         var eventExists = false;
-        event.boundEvents.modals.forEach(function(e) {
+        event.boundEvents.modals.forEach(function (e) {
           if (e.target === toggle && e.event === event.click() && e.fn === toggleClick) {
             eventExists = true;
           }

--- a/lib/js/patterns/modal.js
+++ b/lib/js/patterns/modal.js
@@ -73,7 +73,17 @@ function modal () {
   function bindModals (node) {
     if (!node) {
       toggles.forEach(function (toggle) {
-        event.add(toggle, event.click(), toggleClick);
+        var eventExists = false;
+        event.boundEvents.modals.forEach(function(e) {
+          if (e.target === toggle && e.event === event.click() && e.fn === toggleClick) {
+            eventExists = true;
+          }
+        });
+
+        if (!eventExists) {
+          event.boundEvents.modals.push({target: toggle, event: event.click(), fn: toggleClick});
+          event.add(toggle, event.click(), toggleClick);
+        }
       });
     } else {
       event.add(node, event.click(), toggleClick);
@@ -98,13 +108,13 @@ function modal () {
     }
   }
 
-  function toggleClick (e) {
-    event.preventDefault(e);
-    var modalId = e.target.getAttribute('data-modal');
-    bus.emit('modal:open', {id: modalId});
-  }
-
   bus.emit('modal:bind');
+}
+
+function toggleClick (e) {
+  event.preventDefault(e);
+  var modalId = e.target.getAttribute('data-modal');
+  bus.emit('modal:open', {id: modalId});
 }
 
 export default modal;


### PR DESCRIPTION
This fixes the "duplicate modal listener" issue detailed in #954.

Similar to the pattern in [dropdowns](https://github.com/Esri/calcite-web/blob/master/lib/js/patterns/dropdown.js#L49), check if the `click` event is already there before adding it to the modal toggles.

Note that `toggleClick` is moved outside the function `modal`. Otherwise, when calling `modal()` multiple times, duplicate events are getting bound. This is because the [toggle click method](https://github.com/skitterm/calcite-web/blob/058ec14ac0ddf3d71d24c16d97b73bf81bedd38f/lib/js/patterns/modal.js#L78) is a different instance of the function each time `modal()` is called. Sticking it outside of the `modal` function ensures that it's the same instance of the function used by all modals (so the `e.fn === toggleClick` conditional is true when we'd expect).

I wasn't sure what to do with [the `else` case](https://github.com/skitterm/calcite-web/blob/058ec14ac0ddf3d71d24c16d97b73bf81bedd38f/lib/js/patterns/modal.js#L89) (when `node` is passed to `bindModals`). I didn't see any usage of `bindModals` being called with `node` as an argument, but maybe that's in there for user customization? If it needs to remain there, it will need a similar "if the event exists, don't add it again" logic.