### PR TITLE
use last commit from local git repository for updated date

### DIFF
--- a/docs/source/data/repo.js
+++ b/docs/source/data/repo.js
@@ -1,4 +1,4 @@
-var request = require('request');
+
 var months = [
   'January',
   'February',
@@ -14,18 +14,11 @@ var months = [
   'December'
 ];
 
-module.exports = function getRelease (cb) {
-  // https://developer.github.com/v3/repos/#get
-  return request({
-    method: 'GET',
-    url: 'https://api.github.com/repos/Esri/calcite-web',
-    json: true,
-    headers: {
-      'User-Agent': 'request'
-    }
-  }, function (err, resp, body) {
-    var date = new Date(body.pushed_at);
-    body.pushed_at = months[date.getMonth()] + ' ' + date.getDate() + ', ' + date.getFullYear();
-    return cb(err, body);
+
+module.exports = function (cb) {
+  require('child_process').exec('git log --pretty=format:"%ad" -n 1', function(err, stdout) {
+    var date = new Date(stdout.trim());
+    var pushed_at = `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+    return cb(err, {pushed_at});
   });
-};
+}

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "node-sass": "^4.9.0",
     "npm-run-series": "^1.0.1",
     "parallelshell": "^3.0.0",
-    "request": "^2.73.0",
     "rerun-script": "^0.6.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.56.5",


### PR DESCRIPTION
Instead of using the current approach of fetching the repo data over GitHub's REST API, this simply parses the local git repo and finds the last commit and uses that date. This will solve the "last updated at NaN, NaN" problem.