### PR TITLE
Toggle Switch: Add attribute selector to input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.4]
+
+### Fixes
+- Fix `.toggle-switch-input` cascade (#977)
+
 ## [1.0.3]
 
 ### Fixes

--- a/lib/sass/calcite-web/components/_switches.scss
+++ b/lib/sass/calcite-web/components/_switches.scss
@@ -95,11 +95,8 @@ $handle-destructive-checked-border-color: $Calcite_Red_a250;
 }
 
 @mixin toggle-switch-input {
-  opacity: 0;
-  height: 0;
-  width: 0;
-  margin: 0;
-  position: absolute;
+  @include visually-hidden;
+  
   // hover
   &:hover + .toggle-switch-track {
     border-color: $switch-hover-border-color;
@@ -191,7 +188,7 @@ $handle-destructive-checked-border-color: $Calcite_Red_a250;
 
 @if $include-switches == true {
   .toggle-switch { @include toggle-switch(); }
-  .toggle-switch-input { @include toggle-switch-input(); }
+  .toggle-switch-input[type] { @include toggle-switch-input(); }
   .toggle-switch-label { @include toggle-switch-label(); }
   .toggle-switch-track { @include toggle-switch-track(); }
   .toggle-switch-destructive { @include toggle-switch-destructive(); }


### PR DESCRIPTION
`input[type="checkbox"], input[type="radio]"` in `_forms.scss` overrides the `.toggle-switch-input` styles. In some instances, this leads to `.toggle-switch-input` becoming visible.

Adding an empty attribute selector gives `.toggle-switch-input` enough weight to override.