### PR TITLE
Flips form validation icons and message for RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - `radio-group` component (#762)
+-  Improve handling of input validation for RTL (#990)
 
 ## [1.1.0]
 

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -138,6 +138,14 @@
     background-position: right center;
     background-repeat: no-repeat;
   }
+  
+  .input-error, .input-success {
+    html[dir="rtl"] & {
+      padding-left: 24px;
+      padding-right: $baseline / 5;
+      background-position: left center;
+    }
+  }
 
   .input-error-message {
     @include font-size(-2);
@@ -169,6 +177,12 @@
       pointer-events: none;
       border: 8px solid transparent;
       border-bottom-color: $light-red;
+    }
+    &:after, &:before {
+      html[dir="rtl"] & {
+        left: unset;
+        right: 11px;
+      }
     }
     &.is-active, &.is-active:before, &.is-active:after {
       display: inline-block;


### PR DESCRIPTION
Fix for https://github.com/Esri/calcite-web/issues/990 - swaps alignment of icon and error message arrow.