### PR TITLE
Implement additional mixins for supporting RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1]
+
+### Added
+-  New mixins for RTL support: border-left, border-right, border-left-color, border-right-color, position-left, position-right 
+
 ## [1.2.0]
 
 ### Added

--- a/lib/sass/calcite-web/components/_alert.scss
+++ b/lib/sass/calcite-web/components/_alert.scss
@@ -44,15 +44,7 @@
 
   color: currentColor;
   position: absolute;
-  html:not([dir="rtl"]) & {
-    right: $baseline/2;
-  }
-
-  @if ($include-right-to-left) {
-    html[dir="rtl"] & {
-      left: $baseline/2;
-    }
-  }
+  @include position-right($baseline/2);
 }
 
 @mixin alert-full() {

--- a/lib/sass/calcite-web/components/_badges.scss
+++ b/lib/sass/calcite-web/components/_badges.scss
@@ -19,13 +19,7 @@
     @include left();
     padding: $baseline/8 $baseline/4;
     border: 1px solid $lighter-gray;
-    border-left: none;
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        border-left: 1px solid $lighter-gray;
-        border-right: none;
-      }
-    }
+    @include border-right(1px solid $lighter-gray);
   }
 
   @mixin badge-blue() {

--- a/lib/sass/calcite-web/components/_dropdown.scss
+++ b/lib/sass/calcite-web/components/_dropdown.scss
@@ -21,7 +21,7 @@
     color: $darker-gray;
     background-color: $white;
     border-bottom: none;
-    text-align: left;
+    @include text-left();
     border-left: none;
     border-right: none;
     border-top: 1px solid $lightest-gray;
@@ -35,16 +35,7 @@
     }
     &.is-active, &:focus {
       text-indent: -3px;
-      border-left: 3px solid $blue;
-    }
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        text-align: right;
-      }
-      html[dir="rtl"] &.is-active, html[dir="rtl"] &:focus {
-        border-left: none;
-        border-right: 3px solid $blue;
-      }
+      @include border-left(3px solid $blue);
     }
   }
 
@@ -65,12 +56,10 @@
         @extend %icon-font-after;
         @extend .icon-ui-down:before;
         position: absolute;
-        right: .35rem;
+        @include position-right(.35rem);
       }
       @if ($include-right-to-left) {
         html[dir="rtl"] &:after {
-          right: auto;
-          left: .35rem;
           padding-left: 0;
         }
 
@@ -96,13 +85,7 @@
     display: none;
     overflow: auto;
     &.dropdown-right {
-      right: 0;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          right: auto;
-          left: 0;
-        }
-      }
+      @include position-right(0);
     }
   }
 

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -159,7 +159,6 @@
     &:after {
       content: "";
       position: absolute;
-      left: 11px;
       top: -15px;
       width: 0;
       height: 0;
@@ -170,7 +169,6 @@
     &:before {
       content: "";
       position: absolute;
-      left: 11px;
       top: -16px;
       width: 0;
       height: 0;
@@ -179,10 +177,7 @@
       border-bottom-color: $light-red;
     }
     &:after, &:before {
-      html[dir="rtl"] & {
-        left: unset;
-        right: 11px;
-      }
+      @include position-left(11px);
     }
     &.is-active, &.is-active:before, &.is-active:after {
       display: inline-block;

--- a/lib/sass/calcite-web/components/_radio-group.scss
+++ b/lib/sass/calcite-web/components/_radio-group.scss
@@ -27,13 +27,7 @@
   }
 
   &:checked + .radio-group-label + .radio-group-input + .radio-group-label {
-    border-left: none;
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        border-right: none;
-        border-left: 1px solid $lighter-gray;
-      }
-    }
+    @include border-right(1px solid $lighter-gray);
   }
 }
 

--- a/lib/sass/calcite-web/components/_switches.scss
+++ b/lib/sass/calcite-web/components/_switches.scss
@@ -73,18 +73,12 @@ $handle-destructive-checked-border-color: $Calcite_Red_a250;
     width: $handle-size;
     height: $handle-size;
     top: $handle-top-distance;
-    left: $handle-edge-distance;
+    @include position-left($handle-edge-distance);
     background-color: $handle-bg;
     border-radius: 30px;
     border: 2px solid $handle-border-color;
     box-shadow: $handle-shadow;
     @include transition(all 0.25s ease);
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        right: $handle-edge-distance;
-        left: auto;
-      }
-    }
   }
   // alignment fixes for edge
   @supports (-ms-ime-align: auto) { & { top: .4em; }}
@@ -110,15 +104,9 @@ $handle-destructive-checked-border-color: $Calcite_Red_a250;
   &:active + .toggle-switch-track {
     box-shadow: $switch-focus-shadow;
     &:after {
-      left: $handle-active-edge-distance;
+      @include position-left($handle-active-edge-distance);
       border-color: $handle-checked-border-color;
       box-shadow: $handle-active-shadow;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          right: $handle-active-edge-distance;
-          left: auto;
-        }
-      }
     }
   }
   // checked
@@ -126,31 +114,18 @@ $handle-destructive-checked-border-color: $Calcite_Red_a250;
     border-color: $switch-checked-border-color;
     background-color: $switch-checked-bg;
     &:after {
-      right: $handle-edge-distance;
-      left: auto;
+      @include position-right($handle-edge-distance);
       border-color: $handle-checked-border-color;
       box-shadow: $handle-checked-shadow;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          left: $handle-edge-distance;
-          right: auto;
-        }
-      }
     }
   }
   // checked and active
   &:checked:active + .toggle-switch-track {
     box-shadow: $switch-focus-checked-shadow;
     &:after {
-      right: $handle-active-edge-distance;
+      @include position-right($handle-active-edge-distance);
       border-color: $handle-checked-border-color;
       box-shadow: $handle-active-shadow;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-         left: $handle-active-edge-distance;
-         right: auto;
-       }
-     }
    }
  }
   // unchecked focus

--- a/lib/sass/calcite-web/components/_table.scss
+++ b/lib/sass/calcite-web/components/_table.scss
@@ -9,12 +9,9 @@
   border-collapse: collapse;
   border-spacing: 0;
   border: 1px solid $lighter-gray;
-  text-align: left;
+  @include text-left();
   overflow: auto;
   @include font-size(-2);
-  html[dir="rtl"] & {
-    text-align: right;
-  }
 
   > thead {
     background-color: $lightest-gray;
@@ -38,9 +35,7 @@
     border-left: 1px solid $lighter-gray;
     border-right: 1px solid $lighter-gray;
     padding: $baseline/3;
-    html[dir="rtl"] & {
-      text-align: right;
-    }
+    @include text-left();
   }
 
   tr {

--- a/lib/sass/calcite-web/components/_tooltip.scss
+++ b/lib/sass/calcite-web/components/_tooltip.scss
@@ -100,12 +100,10 @@
   .tooltip-left {
     &:after {
       top: auto;
-      right: 100%;
+      @include position-right(100%);
       margin-right: 5px;
       @if ($include-right-to-left) {
         html[dir="rtl"] & {
-          right: auto;
-          left: 100%;
           margin-right: 0;
           margin-left: 5px;
         }
@@ -118,16 +116,12 @@
     &:before {
       top: 50%;
       bottom: 50%;
-      left: -5px;
+      @include position-left(-5px);
       margin-top: -5px;
-      border-left-color: $transparent-black;
+      @include border-left-color($transparent-black);
       @if ($include-right-to-left) {
         html[dir="rtl"] & {
-          left: auto;
-          right: -5px;
           margin-right: 0;
-          border-left-color: transparent;
-          border-right-color: $transparent-black;
         }
       }
       border-bottom: 5px solid transparent;
@@ -137,14 +131,11 @@
   .tooltip-right {
     &:after {
       top: auto;
-      right: auto;
       bottom: 50%;
-      left: 100%;
+      @include position-left(100%);
       margin-left: 5px;
       @if ($include-right-to-left) {
         html[dir="rtl"] & {
-          left: auto;
-          right: 100%;
           margin-left: 0;
           margin-right: 5px;
         }
@@ -154,19 +145,11 @@
 
     &:before {
       top: 50%;
-      right: -5px;
+      @include position-right(-5px);
       bottom: 50%;
       margin-top: -5px;
       margin-right: 0;
-      border-right-color: $transparent-black;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          left: -5px;
-          right: auto;
-          border-left-color: $transparent-black;
-          border-right-color: transparent;
-        }
-      }
+      @include border-right-color($transparent-black);
       border-bottom: 5px solid transparent;
     }
   }

--- a/lib/sass/calcite-web/patterns/_filter-dropdown.scss
+++ b/lib/sass/calcite-web/patterns/_filter-dropdown.scss
@@ -51,13 +51,7 @@
   visibility: hidden;
   margin-top: 3px;
   position: absolute;
-  left: 10px;
-  @if ($include-right-to-left) {
-    html[dir="rtl"] & {
-      left: initial;
-      right: 10px;
-    }
-  }
+  @include position-left(10px);
 }
 
 @mixin filter-link-close() {
@@ -65,14 +59,7 @@
   visibility: hidden;
   margin-top: 4px;
   position: absolute;
-  right: 10px;
-  @if ($include-right-to-left) {
-    html[dir="rtl"] & {
-      right: auto;
-      right: initial;
-      left: 10px;
-    }
-  }
+  @include position-right(10px);
 }
 
 @mixin filter-dropdown-link() {

--- a/lib/sass/calcite-web/patterns/_modal.scss
+++ b/lib/sass/calcite-web/patterns/_modal.scss
@@ -41,15 +41,14 @@
     max-height: 80vh;
     z-index: 102;
     float: none;
+    @include text-left();
     @if ($include-right-to-left) {
       html[dir="rtl"] & {
         float: none;
-        text-align: right;
       }
     }
     background: $white;
     padding: $baseline;
-    text-align: left;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     display: inline-block;

--- a/lib/sass/calcite-web/patterns/_side-nav.scss
+++ b/lib/sass/calcite-web/patterns/_side-nav.scss
@@ -39,13 +39,7 @@
     }
     &.is-active {
       text-indent: -3px;
-      border-left: 3px solid $blue;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          border-left: none;
-          border-right: 3px solid $blue;
-        }
-      }
+      @include border-left(3px solid $blue);
     }
   }
 

--- a/lib/sass/calcite-web/type/_mixins.scss
+++ b/lib/sass/calcite-web/type/_mixins.scss
@@ -129,7 +129,7 @@
       counter-increment: li;
       position: absolute;
       top: 0;
-      left: 0;
+      @include position-left(0);
       height: 100%;
       height: calc(100% - .3em);
       width: 0.75em;
@@ -138,15 +138,11 @@
       @include font-size(1);
       line-height: 1;
       text-align: right;
-      border-right: 2px solid $lighter-gray;
+      @include border-right(2px solid $lighter-gray);
       @if ($include-right-to-left) {
         html[dir="rtl"] & {
-          left: auto;
-          right: 0;
           padding: 0 0 0 .5em;
           text-align: left;
-          border-right: none;
-          border-left: 2px solid $lighter-gray;
         }
       }
     }

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -19,20 +19,20 @@
     -webkit-font-smoothing: subpixel-antialiased;
 
     -webkit-font-feature-settings: "kern";
-       -moz-font-feature-settings: "kern";
-            font-feature-settings: "kern";
+    -moz-font-feature-settings: "kern";
+    font-feature-settings: "kern";
 
     font-kerning: normal;
 
     text-rendering: optimizeLegibility;
 
-     -moz-font-feature-settings : 'liga= 1','calt=0';
-     -moz-font-feature-settings : "liga" 1,"calt" 0;
-     -webkit-font-feature-settings : "liga" 1,"calt" 0;
-     -ms-font-feature-settings : 'liga= 1','calt=0';
-     -o-font-feature-settings : "liga" 1,"calt" 0;
-     font-feature-settings : "liga" 1,"calt" 0;
-  }
+    -moz-font-feature-settings : 'liga= 1','calt=0';
+    -moz-font-feature-settings : "liga" 1,"calt" 0;
+    -webkit-font-feature-settings : "liga" 1,"calt" 0;
+    -ms-font-feature-settings : 'liga= 1','calt=0';
+    -o-font-feature-settings : "liga" 1,"calt" 0;
+    font-feature-settings : "liga" 1,"calt" 0;
+ }
 
   form,
   select,

--- a/lib/sass/calcite-web/type/_styles.scss
+++ b/lib/sass/calcite-web/type/_styles.scss
@@ -106,13 +106,7 @@
     @include avenir-regular();
     @include gutter-left(1);
     color: $darker-gray;
-    border-left: 3px solid $lighter-gray;
-    @if ($include-right-to-left) {
-      html[dir="rtl"] & {
-        border-left: none;
-        border-right: 3px solid $lighter-gray;
-      }
-    }
+    @include border-left(3px solid $lighter-gray);
   }
 
   blockquote,

--- a/lib/sass/calcite-web/utils/_border.scss
+++ b/lib/sass/calcite-web/utils/_border.scss
@@ -1,0 +1,43 @@
+@mixin border-left($width, $style, $color) {
+  border-left: $width $style $color;
+
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      border-left: none;
+      border-right: $width $style $color;
+    }
+  }
+}
+
+@mixin border-right($width, $style, $color) {
+  border-right: $width $style $color;
+
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      border-right: none;
+      border-left: $width $style $color;
+    }
+  }
+}
+
+@mixin border-left-color($color) {
+  border-left-color: $color;
+
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      border-left-color: transparent;
+      border-right-color: $color;
+    }
+  }
+}
+
+@mixin border-right-color($color) {
+  border-right-color: $color;
+
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      border-right-color: transparent;
+      border-left-color: $color;
+    }
+  }
+}

--- a/lib/sass/calcite-web/utils/_border.scss
+++ b/lib/sass/calcite-web/utils/_border.scss
@@ -1,21 +1,21 @@
-@mixin border-left($width, $style, $color) {
-  border-left: $width $style $color;
+@mixin border-left($style) {
+  border-left: $style;
 
   @if ($include-right-to-left) {
     html[dir="rtl"] & {
       border-left: none;
-      border-right: $width $style $color;
+      border-right: $style;
     }
   }
 }
 
-@mixin border-right($width, $style, $color) {
-  border-right: $width $style $color;
+@mixin border-right($style) {
+  border-right: $style;
 
   @if ($include-right-to-left) {
     html[dir="rtl"] & {
       border-right: none;
-      border-left: $width $style $color;
+      border-left: $style;
     }
   }
 }

--- a/lib/sass/calcite-web/utils/_positioning.scss
+++ b/lib/sass/calcite-web/utils/_positioning.scss
@@ -1,0 +1,21 @@
+@mixin position-left($left) {
+  left: $left;
+
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      left: auto;
+      right: $left;
+    }
+  }
+}
+
+@mixin position-right($right) {
+  right: $right;
+
+  @if ($include-right-to-left) {
+    html[dir="rtl"] & {
+      right: auto;
+      left: $right;
+    }
+  }
+}

--- a/lib/sass/calcite-web/utils/_utils.scss
+++ b/lib/sass/calcite-web/utils/_utils.scss
@@ -5,6 +5,7 @@
 //  ↳ components → _utility-mixins.md
 @import "animation";
 @import "appearance";
+@import "border";
 @import "box-sizing";
 @import "box-shadow";
 @import "calc";
@@ -13,6 +14,7 @@
 @import "overflow";
 @import "prefixer";
 @import "inline";
+@import "positioning";
 @import "responsive";
 @import "transform";
 @import "transition";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calcite-web",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcite-web",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SASS & CSS Framework for Esri websites",
   "private": true,
   "homepage": "https://github.com/esri/calcite-web",


### PR DESCRIPTION
As we are supporting RTL with our app that is using CW, we found a series of missing mixins:
- position-right -> position:right (right is already used for float: right)
- position-left -> position:left  (left is already used for float: left)
- border-right
- border-left
- border-color-right
- border-color-left
