### PR TITLE
#1023 - Alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - :warning: Removed Button Groups
 - :warning: Removed Branding section under patterns
 - :warning: Removed Drawers
+- :warning: DOM structure of Alerts has changed (#1023)
 
 #### Patterns
 Several patterns were removed which are now replaced by the [global-nav component](https://github.com/esri/global-nav):

--- a/docs/source/documentation/components/_alerts.md
+++ b/docs/source/documentation/components/_alerts.md
@@ -1,3 +1,68 @@
+<div class="panel panel-gray leader-1 trailer-1">
+<mark class='label label-blue'>Calcite Web 2.0 Update</mark>
+<p class='leader-half trailer-0 font-size--1'>
+The div structure of alerts has changed. To update alerts, change the structure to match the new structure tomorrow.
+</p>
+</div>
+
 Alerts are used to inform users of state changes, errors, or successful actions. Alerts are only visible if they have the `is-active` class. Without as `is-active` class, the alert will be set to `display: none;`
 
-Calcite does not manage alert classes by default - you will have to write your own JavaScript handlers for this.
+Calcite Web does not manage class assignment, invocation, or dismissal logic for alerts - you will have to write your own JavaScript handlers for this.
+
+An alert can consist of up to three children - `alert-icon`, `alert-content`, and `alert-close`. At a minimum, an alert must contain an `alert-content` child div.  
+
+#### Alert Icons
+It's recommended to pair a status icon with your alert. Pairing an alert status with an icon helps reinforce the intent of the message, and ensures accessibility.
+
+<div class="alert alert-red is-active">
+<div class="alert-icon">
+     {% icon 'check-circle', size=24 %}
+</div>
+<div class="alert-content">
+    You don't have enough credits for that.
+</div>
+<button class="alert-close" aria-label="Close">
+  {% icon 'x', size=24 %}
+</button>
+</div>
+&nbsp;
+
+#### Alert Actions
+Sometimes it can be useful to provide a follow-up action or contextual link to a user within an alert. Place a `btn-link` element in a trailing position to your alert copy.
+
+<div class="alert alert-yellow is-active">
+<div class="alert-content">
+  You don't have enough credits to perform that action.
+  <a class="btn-link">Get more credits.</a>
+</div>
+<button class="alert-close" aria-label="Close">
+  {% icon 'x', size=24 %}
+</button>
+</div>
+&nbsp;
+
+<div class="alert alert-green is-active">
+<div class="alert-icon">
+  {% icon 'check-circle', size=24 %}
+</div>
+<div class="alert-content">
+   You successfully invited 4 members to the feature layer  <a class="btn-link">2019 Franchise Location Sales Map</a>
+</div>
+<button class="alert-close" aria-label="Close">
+  {% icon 'x', size=24 %}
+</button>
+</div>
+&nbsp;
+
+#### Auto-dismissal
+It's recommended to use an explicit close button. If you decide to auto-dismiss alerts, ensure the duration of the alert's visibility is long enough for a user to read it. Don't place any follow-up actions in an auto-dismissable alert.
+
+<div class="alert alert-red is-active">
+<div class="alert-icon">
+  {% icon 'exclamation-mark-triangle', size=24 %}
+</div>
+<div class="alert-content">
+  You don't have enough credits for that.
+</div>
+</div>
+&nbsp;

--- a/docs/source/documentation/components/sample-code/_alerts.html
+++ b/docs/source/documentation/components/sample-code/_alerts.html
@@ -1,6 +1,11 @@
 <div class="alert {{modifier}} is-active">
-  Something Happened!
+  <div class="alert-icon">
+    {% icon 'circle-filled', size=24 %}
+  </div>
+  <div class="alert-content">
+    Something happened that you may want to know about.
+  </div>
   <button class="alert-close" aria-label="Close">
-    {% icon 'x', size=24, classes="svg-icon" %}
+    {% icon 'x', size=24 %}
   </button>
 </div>

--- a/lib/sass/calcite-web/components/_alert.scss
+++ b/lib/sass/calcite-web/components/_alert.scss
@@ -6,52 +6,78 @@
 
 @mixin alert() {
   @include font-size(-1);
-  padding: $baseline/2 $baseline/2;
   @include text-color($transparent-black);
-  background-color: $lightest-blue;
-  position: relative;
   display: none;
+  position: relative;
+  border-top: 3px solid;
   z-index: 100;
   max-width: 40em;
-  border: 1px solid $blue;
-  @include box-shadow($box-shadow);
-  @include link-color($off-black, $black);
+  border-radius: 2px 2px 0 0;
+  box-shadow: 0 0 12px 0 rgba($black, 0.15);
   &.is-active {
-    display: block;
-  }
-  a:hover {
-    color: $transparent-black;
+    display: flex;
   }
 }
 
-@mixin alert-red() {
-  background-color: $lightest-red;
-  border-color: $light-red;
+@mixin alert-element-base() {
+  padding: $baseline/2 $baseline/2;
+  flex: 0 0 auto;
+  & * {
+    position: relative;
+  }
+  & svg {
+    vertical-align: top;
+    height: 1.25rem;
+    width: 1.25rem;
+  }
 }
 
-@mixin alert-yellow() {
-  background-color: $lightest-yellow;
-  border-color: $yellow;
+@mixin alert-icon() {
+  @include alert-element-base;
+  display: flex;
+  align-items: center;
 }
 
-@mixin alert-green() {
-  background-color: $lightest-green;
-  border-color: $light-green;
+@mixin alert-content() {
+  @include alert-element-base;
+  flex: 1 1 auto;
+  & a {
+    font-size: inherit;
+  }
+  &:first-child {
+    padding-left: $baseline;
+    html[dir="rtl"] & {
+      padding-left: initial;
+      padding-right: $baseline;
+    }
+  }
 }
 
 @mixin alert-close() {
-  @include btn-link;
-
-  color: currentColor;
-  position: absolute;
-  html:not([dir="rtl"]) & {
-    right: $baseline/2;
+  @include alert-element-base;
+  @include transition(all .15s ease-in-out);
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  position: relative;
+  & svg {
+    @include transition(all .15s ease-in-out);
+    fill: $darker-gray;
   }
+  &:hover, &:focus {
+    background-color: $off-white;
+  }
+  &:active {
+    background-color: $lightest-gray;
+  }
+}
 
-  @if ($include-right-to-left) {
-    html[dir="rtl"] & {
-      left: $baseline/2;
-    }
+@mixin alert-color($color) {
+  border-top-color: $color;
+  & .alert-icon svg {
+    fill: $color;
   }
 }
 
@@ -59,23 +85,34 @@
   max-width: none;
 }
 
-@if $include-alerts == true {
+@if $include-alerts==true {
   .alert {
     @include alert();
-  }
-  .alert-red {
-    @include alert-red();
-  }
-  .alert-yellow {
-    @include alert-yellow();
-  }
-  .alert-green {
-    @include alert-green();
   }
   .alert-close {
     @include alert-close();
   }
+  .alert-content {
+    @include alert-content();
+  }
+  .alert-icon {
+    @include alert-icon();
+  }
   .alert-full {
     @include alert-full();
+  }
+
+  $alertColors: 
+  '' $blue,
+  '-red' $red,
+  '-yellow' $yellow,
+  '-green' $green;
+
+  @each $alertColor in $alertColors {
+    $name: nth($alertColor, 1);
+    $color: nth($alertColor, 2);
+    .alert#{$name} {
+      @include alert-color($color);
+    }
   }
 }


### PR DESCRIPTION
PR for https://github.com/Esri/calcite-web/issues/1023.

Here’s an update to the alert component. It should match the designs we’ve talked about pretty closely. Tested in Chrome, FF, Safari, Edge, IE11

**Changes:**

- Alerts now use Flexbox for positioning elements
- Additional wrapping classes have been added to content, close button, and icon
- Hit box for “x” has been made to flex to the height of the alert, with a hover /active state (useful for hit area when alerts break to multiple lines
- No in-page positioning is provided. We provide positioning guidelines on the Calcite docs site, and the invocation and dismissal will likely be controlled by logic outside CW.
- SVG children of `alert-icon` have their fill color set to match the alert's accent color.
- SVG children of `alert-icon` and `alert-close` have their height set.
- SVG children no longer use `svg-icon` as we were unsetting as much as we used from it.
- Order of flex children isn't enforced.... So technically you could place your items in any order, we'll rely on documentation to enforce [icon - content - close]

**Questions / Need feedback on:**

- I struggled with how much "design documentation" to put here vs. the eventual Calcite docs page, I think some of the iconography, dismissal stuff can eventually go there.
- We could more clearly document _which_ icons are appropriate for use (filled, non-filled, etc).
- The shadow level, and shade of "yellow" could probably be changed (I know we talked about more yellow / golden shade).
- The focus state may be too subtle.