### PR TITLE
#1021 - Dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - Table: table-minimal
 
+### Updates
+- Dropdown styling has been updated (#1021)
+
 #### Icons
 - All icons in the [calcite-ui-icons](https://github.com/esri/calcite-ui-icons/) set are now available in two syles and three sizes
 - `svg-icon-before` and `svg-icon-after` classes for spacing icons from text
@@ -28,6 +31,7 @@ Several patterns were removed which are now replaced by the [global-nav componen
 - :warning: removed `icon-flush`. Default doesn't apply padding, so no need now.
 - :warning: `svg-icon` class no longer sets size of icon, use `width` and `height` attributes
 - `dropdown` and `accordion` components must use SVG (no icon font)
+
 
 ## [1.2.0]
 

--- a/docs/source/documentation/components/sample-code/_dropdowns.html
+++ b/docs/source/documentation/components/sample-code/_dropdowns.html
@@ -6,12 +6,14 @@
   <!-- extends side-nav -->
   <nav class="dropdown-menu {{modifier}}" role="menu">
     <!-- extends side-nav-link -->
-    <span class="dropdown-title">Some Options</span>
-    <a href="#" class="dropdown-link" role="menu-item">Option 1 that has a really long text.</a>
-    <a href="#" class="dropdown-link" role="menu-item">Option 2</a>
-    <a href="#" class="dropdown-link" role="menu-item">Option 3</a>
-    <span class="dropdown-title">More Options</span>
-    <button class="dropdown-link" role="menu-item">Option 4</button>
-    <a href="#" class="dropdown-link" role="menu-item">Option 5</a>
+    <span class="dropdown-title">Sort By</span>
+    <a href="#" class="dropdown-link" role="menu-item">Owner </a>
+    <a href="#" class="dropdown-link is-active" role="menu-item">Date Modified</a>
+    <a href="#" class="dropdown-link" role="menu-item">Title</a>
+    <a href="#" class="dropdown-link" role="menu-item">Popularity or an option with a long title</a>
+    <a href="#" class="dropdown-link" role="menu-item">Relevance</a>
+    <span class="dropdown-title">Sort Direction</span>
+    <a href="#" class="dropdown-link" role="menu-item">Alphabetical</a>
+    <a href="#" class="dropdown-link is-active" role="menu-item">Reverse Alphabetical</a>
   </nav>
 </div>

--- a/lib/sass/calcite-web/components/_dropdown.scss
+++ b/lib/sass/calcite-web/components/_dropdown.scss
@@ -45,7 +45,7 @@
 
 @mixin dropdown-element-base() {
   @include font-size(-2);
-  @include transition(color 0.15s ease-in-out, background-color 0.15s ease-in-out);
+  @include transition(all 0.15s ease-in-out);
   display: block;
   color: $darker-gray;
   background-color: transparent;

--- a/lib/sass/calcite-web/components/_dropdown.scss
+++ b/lib/sass/calcite-web/components/_dropdown.scss
@@ -7,82 +7,97 @@
 @mixin dropdown {
   position: relative;
   display: inline-block;
+  
   &.is-active .dropdown-menu {
-    display: block;
+    @include transition-delay(0ms);
+    @include transform(translate3d(0, .25rem, 0));
+    opacity: 1;
+    visibility: visible;
   }
 }
 
-  @mixin dropdown-link() {
-    position: relative;
-    display: block;
-    @include box-sizing(border-box);
-    padding: $baseline/3;
-    @include font-size(-2);
-    color: $darker-gray;
-    background-color: $white;
-    border-bottom: none;
-    text-align: left;
-    border-left: none;
-    border-right: none;
-    border-top: 1px solid $lightest-gray;
-    white-space: nowrap;
-    cursor: pointer;
-    width: 100%;
-    &:hover {
-      background-color: $off-white;
-      text-decoration: none;
-      color: $darker-gray;
-    }
-    &.is-active, &:focus {
-      text-indent: -3px;
-      border-left: 3px solid $blue;
-    }
+@mixin dropdown-menu {
+  @include transition(transform 250ms $easing-function, visibility 0ms linear 250ms, opacity 250ms $easing-function);
+  @include transform(translate3d(0, -.5rem, 0));
+  visibility: hidden;
+  opacity: 0;
+  display: block;
+  position: absolute;
+  z-index: 200;
+  overflow: auto;
+  width: auto;
+  min-width: 12.5rem;
+  max-width: 100%;
+  background: $white;
+  border: 1px solid $lighter-gray;
+  box-shadow: 0 0 12px 0 rgba($black, 0.15);
+
+  &.dropdown-right {
+    right: 0;
     @if ($include-right-to-left) {
       html[dir="rtl"] & {
-        text-align: right;
-      }
-      html[dir="rtl"] &.is-active, html[dir="rtl"] &:focus {
-        border-left: none;
-        border-right: 3px solid $blue;
+        right: auto;
+        left: 0;
       }
     }
   }
+}
 
-  @mixin dropdown-title() {
-    @include dropdown-link();
+@mixin dropdown-element-base() {
+  @include font-size(-2);
+  @include transition(color 0.15s ease-in-out, background-color 0.15s ease-in-out);
+  display: block;
+  color: $darker-gray;
+  background-color: transparent;
+}
+
+@mixin dropdown-title() {
+  @include dropdown-element-base();
+  margin: 0 $baseline -1px $baseline;
+  padding: $baseline/2 0;
+  border-bottom: 1px solid $lightest-gray;
+  font-weight: 600;
+  word-wrap: break-word;
+  cursor: default;
+
+  + .dropdown-link {
+    border-top: 1px solid transparent;
+    &:hover, &:active, &:focus {
+      border-top: 1px solid $lightest-gray;
+    }
+  }
+}
+
+@mixin dropdown-link() {
+  @include dropdown-element-base();
+  @include active-link-dot();
+  padding: $baseline/3 $baseline/1;
+  cursor: pointer;
+ 
+  &.is-active {
+    font-weight: 600;
+  }
+  &:hover, &:focus, &:active {
     background-color: $off-white;
-    cursor: auto;
+    color: $darkest-gray;
+    text-decoration: none;
   }
-
-  @mixin dropdown-btn {
-    cursor: pointer;
-    position: relative;
+  &:active {
+    background-color: $lightest-gray;
   }
+}
 
-
-  @mixin dropdown-menu {
-    position: absolute;
-    min-width: 200px;
-    @include box-shadow($box-shadow);
-    @extend .side-nav;
-    z-index: 1000;
-    display: none;
-    overflow: auto;
-    &.dropdown-right {
-      right: 0;
-      @if ($include-right-to-left) {
-        html[dir="rtl"] & {
-          right: auto;
-          left: 0;
-        }
-      }
-    }
+@if $include-dropdowns==true {
+  .dropdown {
+    @include dropdown();
   }
-
-@if $include-dropdowns == true {
-  .dropdown { @include dropdown(); }
-  .dropdown-btn { @include dropdown-btn(); }
-  .dropdown-menu { @include dropdown-menu(); }
-  .dropdown-title {@include dropdown-title();}
-  .dropdown-link { @include dropdown-link();}
+  .dropdown-menu {
+    @include dropdown-menu();
+  }
+  .dropdown-title {
+    @include dropdown-title();
+  }
+  .dropdown-link {
+    @include dropdown-link();
+  }
 }

--- a/lib/sass/calcite-web/components/_dropdown.scss
+++ b/lib/sass/calcite-web/components/_dropdown.scss
@@ -47,13 +47,13 @@
   @include font-size(-2);
   @include transition(all 0.15s ease-in-out);
   display: block;
-  color: $darker-gray;
+  color: $dark-gray;
   background-color: transparent;
 }
 
 @mixin dropdown-title() {
   @include dropdown-element-base();
-  margin: 0 $baseline -1px $baseline;
+  margin: 0 $baseline/1.5 -1px $baseline/1.5;
   padding: $baseline/2 0;
   border-bottom: 1px solid $lightest-gray;
   font-weight: 600;
@@ -71,11 +71,11 @@
 @mixin dropdown-link() {
   @include dropdown-element-base();
   @include active-link-dot();
-  padding: $baseline/3 $baseline/1;
+  padding: $baseline/3 $baseline/1.5 $baseline/3  $baseline*1.5;
   cursor: pointer;
  
   &.is-active {
-    font-weight: 600;
+    color: $black;
   }
   &:hover, &:focus, &:active {
     background-color: $off-white;

--- a/lib/sass/calcite-web/utils/_active-link-dot.scss
+++ b/lib/sass/calcite-web/utils/_active-link-dot.scss
@@ -10,7 +10,7 @@
   &:before {
     content: "\2022";
     position: absolute;
-    left: .6rem;
+    left: 1rem;
     opacity: 0;
     color: $gray;
     @include transition(all 0.15s ease-in-out);
@@ -25,7 +25,7 @@
   @if ($include-right-to-left) {
     html[dir="rtl"] &:before {
       left: unset;
-      right: .6rem;
+      right: 1rem;
     }
   }
 }

--- a/lib/sass/calcite-web/utils/_active-link-dot.scss
+++ b/lib/sass/calcite-web/utils/_active-link-dot.scss
@@ -1,0 +1,31 @@
+// ┌─────────────────┐
+// │ Active Link Dot │
+// └─────────────────┘
+//  ↳ http://esri.github.io/calcite-web/documentation/sass/#active-link-dot
+//  ↳ components → _utility-mixins.md
+
+@mixin active-link-dot () {
+  position: relative;
+
+  &:before {
+    content: "\2022";
+    position: absolute;
+    left: .6rem;
+    opacity: 0;
+    color: $gray;
+    @include transition(all 0.15s ease-in-out);
+  }
+  &:hover:before {
+    opacity: 1;
+  }
+  &:focus:before, &.is-active:before {
+    opacity: 1;
+    color: $blue;
+  }
+  @if ($include-right-to-left) {
+    html[dir="rtl"] &:before {
+      left: unset;
+      right: .6rem;
+    }
+  }
+}

--- a/lib/sass/calcite-web/utils/_utils.scss
+++ b/lib/sass/calcite-web/utils/_utils.scss
@@ -17,3 +17,4 @@
 @import "transform";
 @import "transition";
 @import "visibility";
+@import "active-link-dot";


### PR DESCRIPTION
PR for https://github.com/Esri/calcite-web/issues/1021.

This builds on Julio's work to update the style of dropdown menus - there are no structural changes. Tested in Chrome, FF, Safari, Edge. Waiting for https://github.com/Esri/calcite-web/pull/1070 to test in IE 11.

Changes:

- These should now match Online / discussed updates
- Hit areas for dropdown links are now full width, and have distinct hover / focus states
- Introduces an `active-link-dot` mixin to use in future designs
- Uses shadow level / strength from Alerts (https://github.com/Esri/calcite-web/pull/1068)
- Uses invocation animation from Online

Questions / Need feedback on:

- Is using `content: "\2022"` for the pseudo-element active dot sustainable? It makes aligning the active dot with the line-height easy but unsure if there are consequences with translation of the character. Alternatively we can use a bg-color in the pseudo-element.
- I think the current 600 weight items (header, active item) are good candidates for 500 weight treatment.
