### PR TITLE
Input field updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Updates
 - Dropdown styling has been updated (#1021)
 - Tabs styling has been updated
+- updated input height to 42px & added more x padding
 
 #### Icons
 - All icons in the [calcite-ui-icons](https://github.com/esri/calcite-ui-icons/) set are now available in two syles and three sizes

--- a/lib/sass/calcite-web/components/_form.scss
+++ b/lib/sass/calcite-web/components/_form.scss
@@ -57,11 +57,11 @@
   input, select, textarea {
     position: relative;
     display: block;
-    height: 2.25rem;
+    height: 2.625rem;
     width: 100%;
     max-width: 100%;
     margin: .25rem 0 0 0;
-    padding: 0 $baseline / 5;
+    padding: 0 $baseline / 2;
     @include box-sizing(border-box);
     font-family: inherit;
     font-size: modular-scale(-1);


### PR DESCRIPTION
modified height to 42px and added padding on the left of the text.

Based on design and discussion in [date-picker](https://github.com/ArcGIS/calcite-components/issues/58)