### PR TITLE
Update site with deprecation content

### DIFF
--- a/docs/source/assets/css/_doc.scss
+++ b/docs/source/assets/css/_doc.scss
@@ -246,3 +246,17 @@ mark {
   padding-top: $baseline * .8;
   padding-bottom: $baseline * .55;
 }
+
+.deprecation-message {
+  margin: 1rem;
+  max-width: 100%;
+}
+
+.deprecation-heading {
+  font-weight: bold;
+}
+
+.deprecation-description {
+  margin: 0;
+  padding: 0;
+}

--- a/docs/source/documentation/get-started/_get-started.md
+++ b/docs/source/documentation/get-started/_get-started.md
@@ -10,7 +10,7 @@ There are three ways to use Calcite Web:
 
 - (a) copying static files into your project
 - (b) installing via a package manager
-- (c) loading files from the cdn
+- (c) loading files from a self-hosted cdn
 
 By default, Calcite Web expects image files to be located at `../`. If your fonts are elsewhere, set the `$font-path` variable
 

--- a/docs/source/documentation/get-started/_static-files.md
+++ b/docs/source/documentation/get-started/_static-files.md
@@ -1,11 +1,1 @@
-This is probably the easiest way, but you won't get any of the helpful Sass mixins. If you're looking to get up and running quickly, just [download the latest release](https://github.com/ArcGIS/calcite-web/releases) and move the zipped files to wherever you keep your assets (CSS, JavaScript, images). Be sure to use [the documentation site](http://esri.github.io/calcite-web/) to copy and paste patterns, components, and even a sample html boilerplate.
-
-You can also use a hosted version of Calcite Web:
-
-```
-<!-- In the head -->
-<link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
-
-<!-- Just before end of body -->
-<script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
-```
+If you're looking to get up and running quickly, just [download the latest release](https://github.com/Esri/calcite-web/releases) and move the zipped files to wherever you keep your assets (CSS, JavaScript, images). Be sure to use [the documentation site](http://esri.github.io/calcite-web/) to copy and paste patterns, components, and even a sample html boilerplate.

--- a/docs/source/documentation/javascript/_importing.md
+++ b/docs/source/documentation/javascript/_importing.md
@@ -48,7 +48,7 @@ If `calcite-web.js` is used on a page with no module syntax, it will just attach
 ```html
 <body>
   ...
-  <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+  <script src="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
   <script>
      calcite.init()
   </script>

--- a/docs/source/documentation/javascript/_importing.md
+++ b/docs/source/documentation/javascript/_importing.md
@@ -43,12 +43,12 @@ require(['path/to/calcite-web.js'], function(calcite){
 
 #### IIFE
 
-If `calcite-web.js` is used on a page with no module syntax, it will just attach itself to `window.calcite`. Here is an example which initializes Calcite from a hosted file on S3:
+If `calcite-web.js` is used on a page with no module syntax, it will just attach itself to `window.calcite`. Here is an example which initializes Calcite from a self-hosted CDN location:
 
 ```html
 <body>
   ...
-  <script src="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+  <script src="https://<self-hosted-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
   <script>
      calcite.init()
   </script>

--- a/docs/source/documentation/patterns/_interactive-overview.md
+++ b/docs/source/documentation/patterns/_interactive-overview.md
@@ -1,3 +1,3 @@
-Interactive patterns rely on `calcite-web.js` to work properly. You must add a reference to `calcite-web.js` (either from the cdn or you can host it yourself). After that, you should startup all the interactive patterns on load with `calcite.init()`.
+Interactive patterns rely on `calcite-web.js` to work properly. You must add a reference to `calcite-web.js`. After that, you should startup all the interactive patterns on load with `calcite.init()`.
 
 For more on using `calcite-web.js` you can view the [JavaScript Documentation](../javascript/).

--- a/docs/source/guides/quickstart/demo.html
+++ b/docs/source/guides/quickstart/demo.html
@@ -157,7 +157,7 @@ layout: false
     </div>
 
     <!-- reference self-hosted calcite-web js -->
-    <script src="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+    <script src="https://<self-hosted-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
 
     <!-- interactive patterns need to be initialized -->
     <script>

--- a/docs/source/guides/quickstart/demo.html
+++ b/docs/source/guides/quickstart/demo.html
@@ -11,7 +11,7 @@ layout: false
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <title>Your Title</title>
     <link rel="shortcut icon" href="/img/favicon.ico">
-    <!-- get calcite-web css from the cdn (use latest version) -->
+    <!-- reference self-hosted calcite-web css -->
     <link rel="stylesheet" href="{{relativePath}}/assets/css/all.css">
     <!--[if lt IE 9]>
       <script src="/assets/javascripts/libs/selectivizr.js"></script>
@@ -156,8 +156,8 @@ layout: false
       </div>
     </div>
 
-    <!-- get calcite-web js from the cdn (use latest version) -->
-    <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+    <!-- reference self-hosted calcite-web js -->
+    <script src="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
 
     <!-- interactive patterns need to be initialized -->
     <script>

--- a/docs/source/guides/quickstart/index.html
+++ b/docs/source/guides/quickstart/index.html
@@ -27,7 +27,7 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
     <title>Your Title</title>
     <link rel="shortcut icon" href="/img/favicon.ico">
     <!-- reference self-hosted calcite-web css -->
-    <link rel="stylesheet" href="<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
+    <link rel="stylesheet" href="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
     <!--[if lt IE 9]>
       <script src="/assets/javascripts/libs/selectivizr.js"></script>
       <script src="/assets/javascripts/libs/html5shiv.js"></script>
@@ -43,7 +43,7 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
     </div>
 
     <!-- reference self-hosted calcite-web js -->
-    <script src="<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+    <script src="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
 
     <!-- interactive patterns need to be initialized -->
     <script>

--- a/docs/source/guides/quickstart/index.html
+++ b/docs/source/guides/quickstart/index.html
@@ -27,7 +27,7 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
     <title>Your Title</title>
     <link rel="shortcut icon" href="/img/favicon.ico">
     <!-- reference self-hosted calcite-web css -->
-    <link rel="stylesheet" href="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
+    <link rel="stylesheet" href="https://<self-hosted-url>/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
     <!--[if lt IE 9]>
       <script src="/assets/javascripts/libs/selectivizr.js"></script>
       <script src="/assets/javascripts/libs/html5shiv.js"></script>
@@ -43,7 +43,7 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
     </div>
 
     <!-- reference self-hosted calcite-web js -->
-    <script src="https://<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+    <script src="https://<self-hosted-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
 
     <!-- interactive patterns need to be initialized -->
     <script>

--- a/docs/source/guides/quickstart/index.html
+++ b/docs/source/guides/quickstart/index.html
@@ -26,8 +26,8 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <title>Your Title</title>
     <link rel="shortcut icon" href="/img/favicon.ico">
-    <!-- get calcite-web css from the cdn (use latest version) -->
-    <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
+    <!-- reference self-hosted calcite-web css -->
+    <link rel="stylesheet" href="<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
     <!--[if lt IE 9]>
       <script src="/assets/javascripts/libs/selectivizr.js"></script>
       <script src="/assets/javascripts/libs/html5shiv.js"></script>
@@ -42,8 +42,8 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
       <!-- content of footer -->
     </div>
 
-    <!-- get calcite-web js from the cdn (use latest version) -->
-    <script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
+    <!-- reference self-hosted calcite-web js -->
+    <script src="<self-hosted-s3-bucket-url>/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
 
     <!-- interactive patterns need to be initialized -->
     <script>
@@ -56,7 +56,7 @@ To get started creating a page in Calcite Web we'll start with, well, the page!
 The above page does a lot of things:
 
 1. General HTML boilerplate (`meta`, `title`, conditional IE classes, `head` and `body` tags)
-2. Load the current version of Calcite Web's CSS and JS from the CDN
+2. Load the current version of Calcite Web's CSS and JS from a self-hosted CDN
 3. Set up basic page containers (for sticky footers/drawers if they are used in the future)
 4. Initialize interactive patterns which rely on `calcite-web.js`
 

--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -60,7 +60,7 @@ Calcite Web has everything you need to quickly build excellent web experiences a
   <div class="column-20 pre-2">
     <div class="column-12 first-column">
       <h3>Easy to Get Started</h3>
-      <p class="font-size-1">Use Calcite Web from your favorite package manager, download it, or just use it off the CDN.</p>
+      <p class="font-size-1">Use Calcite Web from your favorite package manager, or download it to self-host the files.</p>
     </div>
   </div>
 
@@ -71,18 +71,10 @@ Calcite Web has everything you need to quickly build excellent web experiences a
   </div>
 
   <div class="column-12 leader-1">
-{% markdown %}
-#### CDN
-
-Calcite Web can also be referenced directly from the CDN:
-
-```html
-<link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/css/calcite-web.min.css">
-<script src="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/{{data.pkg.version}}/js/calcite-web.min.js"></script>
-```
-{% endmarkdown %}
-
-  </div>
+      <h4>Self Hosted</h4>
+      <p>Calcite Web can also be used by referencing self hosted files.</p>
+      <a href="https://github.com/Esri/calcite-web/releases" class="btn btn-clear">Browse releases</a>
+    </div>
 </div>
 
 <div class="panel padding-leader-3 padding-trailer-2">

--- a/docs/source/layouts/_doc.html
+++ b/docs/source/layouts/_doc.html
@@ -5,7 +5,7 @@
   <div class="grid-container">
     <div class="column-24">
      <h1 class="sub-nav-title text-white leader-1">Documentation</h1>
-     <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
+     <a href="https://github.com/Esri/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
      <nav class="sub-nav-list tablet-hide" role="navigation" aria-labelledby="subnav">
       {% for title, sec in data.table_of_contents %}
       {% set slug = '/documentation/' + sec.base + '/' %}

--- a/docs/source/layouts/_examples.html
+++ b/docs/source/layouts/_examples.html
@@ -5,7 +5,7 @@
     <div class="grid-container">
       <div class="column-24">
         <h1 class="sub-nav-title text-white leader-1">Examples</h1>
-        <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
+        <a href="https://github.com/Esri/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
         <nav class="sub-nav-list" role="navigation" aria-labelledby="subnav">
           <a class="sub-nav-link {% if active == 'overview' %}is-active{% endif %}" href="{{relativePath}}/examples">Overview</a>
           <a href="{{relativePath}}/examples/core" class="sub-nav-link {% if active == 'core' %} is-active {% endif %}">Basic Pages</a>

--- a/docs/source/layouts/_guide.html
+++ b/docs/source/layouts/_guide.html
@@ -5,7 +5,7 @@
   <div class="grid-container">
     <div class="column-24">
       <h1 class="sub-nav-title text-white leader-1">Guides</h1>
-      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
+      <a href="https://github.com/Esri/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
       <nav class="sub-nav-list">
         <a class="sub-nav-link {% if url == '/guides/' %}is-active{% endif %}" href="{{relativePath}}/guides/">Overview</a>
         <a class="sub-nav-link {% if url == '/guides/quickstart/' %}is-active{% endif %}" href="{{relativePath}}/guides/quickstart/">Quickstart</a>

--- a/docs/source/layouts/_layout.html
+++ b/docs/source/layouts/_layout.html
@@ -102,6 +102,13 @@
 
     <!-- Sample HTML -->
     <header class="top-nav">
+      <!-- deprecation message -->
+      <div class="alert is-active deprecation-message">
+        <span class="deprecation-heading">Calcite Web is deprecated.</span>
+        <p class="deprecation-description">This project is no longer maintained and is not recommended for future
+          development. Visit the <a href="https://github.com/Esri/calcite-web">Calcite Web GitHub repository</a> for more
+          information.</p>
+      </div>
       <div class="grid-container">
         <div class="column-24">
           <!-- desktop sized navigation -->

--- a/docs/source/layouts/_quick-reference.html
+++ b/docs/source/layouts/_quick-reference.html
@@ -6,7 +6,7 @@
   <div class="grid-container">
     <div class="column-24">
       <h1 class="sub-nav-title text-white leader-1">Quick Reference</h1>
-      <a href="https://github.com/ArcGIS/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
+      <a href="https://github.com/Esri/calcite-web/releases" class="btn btn-white icon-ui-download right leader-1 trailer-1 tablet-hide" title="Download Latest Release" target="blank">Download Latest Release</a>
       <nav class="sub-nav-list">
         <a class="sub-nav-link {% if url == '/quick-reference/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/">Component Status</a>
         <a class="sub-nav-link {% if url == '/quick-reference/class-sheet/' %}is-active{% endif %}" href="{{relativePath}}/quick-reference/class-sheet/">Class Sheet</a>

--- a/docs/source/table_of_contents.yml
+++ b/docs/source/table_of_contents.yml
@@ -577,15 +577,6 @@ components:
           modifiers:
             - 'esri-logo-reverse'
             - 'esri-logo-condensed'
-    - group: 'Proposed'
-      hidden: true
-      pages:
-        - title: 'Example'
-          hidden: true
-          status: 'inprogress'
-        - title: 'Example'
-          hidden: true
-          status: 'unplanned'
 patterns:
   title: 'Patterns'
   base: patterns


### PR DESCRIPTION
🫡

Adds deprecation content to the Calcite Web documentation site:

- Persistent alert across all pages.
- Removal of any "patterns.esri.com" CDN references
- Addition of "self host" verbiage
- Removal of placeholder items in status page

We will add more messaging to this repository in the future, but we want to immediately remove the outdated CDN links, per security request from IST.

@paulcpederson - I think you are the only one able to review this 😭 
cc @jcfranco @driskull @juliepowell @geospatialem @brittneytewks

<img width="1200" alt="Screenshot 2023-10-13 at 9 52 08 AM" src="https://github.com/Esri/calcite-web/assets/4733155/284e6891-c03a-4b9e-b21d-e0495da152be">
<img width="300" alt="Screenshot 2023-10-13 at 9 52 18 AM" src="https://github.com/Esri/calcite-web/assets/4733155/ba9bf629-b063-450d-a902-6aa53956603f">
